### PR TITLE
NODE-1716 Fix response body wrapping

### DIFF
--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -23,8 +23,8 @@ module.exports = function initialize(shim, Koa) {
   })
   shim.wrapReturn(Koa.prototype, 'createContext', wrapCreateContext)
   function wrapCreateContext(shim, fn, fnName, context) {
-    context.__NR_body = context.body
-    Object.defineProperty(context, 'body', {
+    context.__NR_body = context.response.body
+    Object.defineProperty(context.response, '_body', {
       get: function getBody() {
         return this.__NR_body
       },

--- a/tests/versioned/koa.tap.js
+++ b/tests/versioned/koa.tap.js
@@ -36,7 +36,7 @@ tap.test('Koa instrumentation', function(t) {
       return next()
     })
     app.use(function two(ctx) {
-      ctx.body = 'done'
+      ctx.response.body = 'done'
     })
 
     helper.agent.on('transactionFinished', function(tx) {
@@ -228,7 +228,11 @@ tap.test('Koa instrumentation', function(t) {
 
   function run() {
     server = app.listen(0, function() {
-      http.get({port: server.address().port}).end()
+      http.get({port: server.address().port}, function(res) {
+        if (res.body) {
+          t.equal(res.body, 'done')
+        }
+      }).end()
     })
   }
 })


### PR DESCRIPTION
## CHANGE LOG

* Updated instrumentation to hook into `context.response._body` instead of `context.body`.

  This ensures delegation is not overridden regardless of whether users define the body directly on `ctx`, or on `ctx.response`. Thanks @qventura for the investigation!

## INTERNAL LINKS

## NOTES
