### PR TITLE
NODE-1740 move methods from devDeps to deps

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+## CHANGELOG
+
+## INTERNAL LINKS
+
+## NOTES

--- a/package.json
+++ b/package.json
@@ -21,13 +21,14 @@
     "koa": "^2.5.0",
     "koa-route": "^3.2.0",
     "koa-router": "^7.4.0",
-    "methods": "^1.1.2",
-    "newrelic": "^3.1.0",
+    "newrelic": "^3.3.1",
     "semver": "^5.5.0",
     "tap": "^10.7.3"
   },
-  "dependencies": {},
+  "dependencies": {
+    "methods": "^1.1.2"
+  },
   "peerDependencies": {
-    "newrelic": "^3.2.0"
+    "newrelic": "^3.3.1"
   }
 }


### PR DESCRIPTION
## CHANGELOG

* Moved `methods` from `devDependencies` to `dependencies`.

  This fixes an error caused by an oversight in the last release, which included `methods` used as a core dep.

## INTERNAL LINKS

## NOTES