### PR TITLE
peerDeps newrelic 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "koa": "^2.5.0",
     "koa-route": "^3.2.0",
     "koa-router": "^7.4.0",
-    "newrelic": "^3.3.1",
+    "newrelic": "^4.0.0",
     "semver": "^5.5.0",
     "tap": "^10.7.3"
   },
@@ -29,6 +29,6 @@
     "methods": "^1.1.2"
   },
   "peerDependencies": {
-    "newrelic": "^3.3.1"
+    "newrelic": ">=3.3.1"
   }
 }


### PR DESCRIPTION
## CHANGELOG

## INTERNAL LINKS

## NOTES

The latest newrelic came out about an hour ago https://www.npmjs.com/package/newrelic , https://github.com/newrelic/node-newrelic/commit/b950b5d76faf0c38ebbe0d198ea254add16d49f1  we are finding we cant shrinkwrap with it because it requires newrelic-koa, and newrelic-koa doesnt yet have a compatible version with 4.x

```
$ npm install newrelic@latest --save

> @newrelic/native-metrics@2.2.0 install ~/my-app-next/node_modules/@newrelic/native-metrics
> node ./lib/pre-build.js install native_metrics

> /usr/local/bin/node ~/my-app-next/node_modules/node-gyp/bin/node-gyp.js clean configure
> /usr/local/bin/node ~/my-app-next/node_modules/node-gyp/bin/node-gyp.js build -j 4 native_metrics
  CXX(target) Release/obj.target/native_metrics/src/native_metrics.o
  CXX(target) Release/obj.target/native_metrics/src/GCBinder.o
  CXX(target) Release/obj.target/native_metrics/src/LoopChecker.o
  CXX(target) Release/obj.target/native_metrics/src/RUsageMeter.o
../src/GCBinder.cpp:47:10: warning: 'MakeCallback' is deprecated [-Wdeprecated-declarations]
    Nan::MakeCallback(
         ^
../node_modules/nan/nan.h:950:3: note: 'MakeCallback' has been explicitly marked deprecated here
  NAN_DEPRECATED inline v8::Local<v8::Value> MakeCallback(
  ^
../node_modules/nan/nan.h:98:40: note: expanded from macro 'NAN_DEPRECATED'
# define NAN_DEPRECATED __attribute__((deprecated))
                                       ^
1 warning generated.
  SOLINK_MODULE(target) Release/native_metrics.node
clang: warning: libstdc++ is deprecated; move to libc++ with a minimum deployment target of OS X 10.9 [-Wdeprecated]
install successful: _newrelic_native_metrics-2_2_0-native_metrics-48-darwin-x64
npm WARN saveError Problems were encountered
npm WARN saveError Please correct and try again.
npm WARN saveError peer invalid: newrelic@^3.3.1, required by @newrelic/koa@1.0.4
ms@2.0.0 node_modules/newrelic/node_modules/https-proxy-agent/node_modules/debug/node_modules/ms -> node_modules/https-proxy-agent/node_modules/ms
- inherits@2.0.3 node_modules/newrelic/node_modules/concat-stream/node_modules/inherits
- core-util-is@1.0.2 node_modules/newrelic/node_modules/concat-stream/node_modules/readable-stream/node_modules/core-util-is
- isarray@1.0.0 node_modules/newrelic/node_modules/concat-stream/node_modules/readable-stream/node_modules/isarray
- process-nextick-args@1.0.7 node_modules/newrelic/node_modules/concat-stream/node_modules/readable-stream/node_modules/process-nextick-args
- safe-buffer@5.0.1 node_modules/newrelic/node_modules/concat-stream/node_modules/readable-stream/node_modules/safe-buffer
- string_decoder@1.0.2 node_modules/newrelic/node_modules/concat-stream/node_modules/readable-stream/node_modules/string_decoder
- util-deprecate@1.0.2 node_modules/newrelic/node_modules/concat-stream/node_modules/readable-stream/node_modules/util-deprecate
- readable-stream@2.2.11 node_modules/newrelic/node_modules/concat-stream/node_modules/readable-stream
- typedarray@0.0.6 node_modules/newrelic/node_modules/concat-stream/node_modules/typedarray
- agent-base@1.0.2 node_modules/newrelic/node_modules/https-proxy-agent/node_modules/agent-base
- debug@2.6.8 node_modules/newrelic/node_modules/https-proxy-agent/node_modules/debug
- extend@3.0.1 node_modules/newrelic/node_modules/https-proxy-agent/node_modules/extend
- https-proxy-agent@0.3.6 node_modules/newrelic/node_modules/https-proxy-agent
- json-stringify-safe@5.0.1 node_modules/newrelic/node_modules/json-stringify-safe
- core-util-is@1.0.2 node_modules/newrelic/node_modules/readable-stream/node_modules/core-util-is
- inherits@2.0.3 node_modules/newrelic/node_modules/readable-stream/node_modules/inherits
- isarray@0.0.1 node_modules/newrelic/node_modules/readable-stream/node_modules/isarray
- string_decoder@0.10.31 node_modules/newrelic/node_modules/readable-stream/node_modules/string_decoder
- readable-stream@1.1.14 node_modules/newrelic/node_modules/readable-stream
- semver@5.3.0 node_modules/newrelic/node_modules/semver
my-app@0.0.1041 ~/my-app-next
├─┬ carbon_web@4.5.3
│ └─┬ carbon_base@1.4.0
│   └─┬ newrelic@1.40.0
│     ├─┬ concat-stream@1.6.0
│     │ ├── inherits@2.0.3
│     │ ├─┬ readable-stream@2.2.11
│     │ │ ├── core-util-is@1.0.2
│     │ │ ├── isarray@1.0.0
│     │ │ ├── process-nextick-args@1.0.7
│     │ │ ├── safe-buffer@5.0.1
│     │ │ ├── string_decoder@1.0.2
│     │ │ └── util-deprecate@1.0.2
│     │ └── typedarray@0.0.6
│     ├─┬ https-proxy-agent@0.3.6
│     │ ├── agent-base@1.0.2
│     │ ├─┬ debug@2.6.8
│     │ │ └── ms@2.0.0
│     │ └── extend@3.0.1
│     ├── json-stringify-safe@5.0.1
│     ├─┬ readable-stream@1.1.14
│     │ ├── core-util-is@1.0.2
│     │ ├── inherits@2.0.3
│     │ ├── isarray@0.0.1
│     │ └── string_decoder@0.10.31
│     └── semver@5.3.0
└─┬ newrelic@4.0.0
  ├── @newrelic/koa@1.0.4
  ├─┬ @newrelic/native-metrics@2.2.0
  │ └── nan@2.10.0
  ├─┬ async@2.6.0
  │ └── lodash@4.17.5
  ├── concat-stream@1.6.2
  ├─┬ https-proxy-agent@2.2.1
  │ ├─┬ agent-base@4.2.0
  │ │ └─┬ es6-promisify@5.0.0
  │ │   └── es6-promise@4.2.4
  │ └── debug@3.1.0
  └── UNMET PEER DEPENDENCY newrelic@^3.3.1

npm WARN @newrelic/koa@1.0.4 requires a peer of newrelic@^3.3.1 but none was installed.
```


```
$ npm shrinkwrap
npm ERR! Darwin 16.7.0
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "shrinkwrap"
npm ERR! node v6.9.1
npm ERR! npm  v3.10.8

npm ERR! Problems were encountered
npm ERR! Please correct and try again.
npm ERR! peer invalid: newrelic@^3.3.1, required by @newrelic/koa@1.0.4
npm ERR!
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     ~/my-app-next/npm-debug.log
```