### PR TITLE
Disabled testing on Node 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,21 @@
 language: node_js
 node_js:
   - "4"
-  - "5"
   - "6"
   - "7"
   - "8"
   - "9"
+  - "10"
 env:
   - SUITE=lint
+  - SUITE=unit
   - SUITE=versioned
 matrix:
   exclude:
     - node_js: "4"
-      env: SUITE=lint
-    - node_js: "5"
       env: SUITE=lint
     - node_js: "6"
       env: SUITE=lint
     - node_js: "7"
       env: SUITE=lint
 script: npm run $SUITE
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "7"
   - "8"
@@ -12,8 +11,6 @@ env:
   - SUITE=versioned
 matrix:
   exclude:
-    - node_js: "4"
-      env: SUITE=lint
     - node_js: "6"
       env: SUITE=lint
     - node_js: "7"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
-[![Coverage Status](https://coveralls.io/repos/github/newrelic/node-newrelic-koa/badge.svg?branch=psvet%2Fcoveralls)](https://coveralls.io/github/newrelic/node-newrelic-koa?branch=psvet%2Fcoveralls)
+[![Coverage Status][1]][2]
 
-New Relic's official Koa framework instrumentation for use with the [Node agent](https://github.com/newrelic/node-newrelic). This module is a dependency of the agent and is installed with it by running:
+New Relic's official Koa framework instrumentation for use with the
+[Node agent](https://github.com/newrelic/node-newrelic). This module is a
+dependency of the agent and is installed with it by running:
 
 ```
 npm install newrelic
 ```
 
-Alternatively, it can be installed and loaded independently based on specific versioning needs:
+Alternatively, it can be installed and loaded independently based on specific
+versioning needs:
+
 ```
 npm install @newrelic/koa
 ```
@@ -20,4 +24,10 @@ require('@newrelic/koa')
 - `koa-router`
 - `koa-route`
 
-For more information, please see the agent [installation guide](https://docs.newrelic.com/docs/agents/nodejs-agent/installation-configuration/install-nodejs-agent), and [compatibility and requirements](https://docs.newrelic.com/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent).
+For more information, please see the agent [installation guide][3], and
+[compatibility and requirements][4].
+
+[1]: https://coveralls.io/repos/github/newrelic/node-newrelic-koa/badge.svg?branch=master
+[2]: https://coveralls.io/github/newrelic/node-newrelic-koa?branch=master
+[3]: https://docs.newrelic.com/docs/agents/nodejs-agent/installation-configuration/install-nodejs-agent
+[4]: https://docs.newrelic.com/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "tap tests/**/*.tap.js",
+    "test": "npm run unit && npm run versioned",
+    "unit": "tap tests/unit/**/*.tap.js",
     "versioned": "versioned-tests --minor -i 2 'tests/versioned/*.tap.js'",
     "lint": "eslint *.js lib tests"
   },

--- a/tests/versioned/package.json
+++ b/tests/versioned/package.json
@@ -5,10 +5,10 @@
   "tests": [
     {
       "engines": {
-        "node": ">=4"
+        "node": "4 || >5"
       },
       "dependencies": {
-        "koa": "1.5"
+        "koa": "^1.5.0"
       },
       "files": [
         "koa-v1.tap.js"
@@ -16,7 +16,7 @@
     },
     {
       "engines": {
-        "node": ">=4 <6"
+        "node": "4"
       },
       "dependencies": {
         "koa": "2.0.0",

--- a/tests/versioned/package.json
+++ b/tests/versioned/package.json
@@ -5,28 +5,19 @@
   "tests": [
     {
       "engines": {
-        "node": "4 || >5"
+        "node": ">=6"
       },
       "dependencies": {
         "koa": "^1.5.0"
       },
       "files": [
         "koa-v1.tap.js"
-      ]
-    },
-    {
-      "engines": {
-        "node": "4"
-      },
-      "dependencies": {
-        "koa": "2.0.0",
-        "koa-router": ">=7.0.0"
-      },
-      "files": [
-        "koa.tap.js",
-        "koa-router.tap.js"
       ],
-      "notes": "Because Koa uses destructuring and the spread operator in later versions, Node v4 & 5 only work on one version."
+      "notes": [
+        "Koa <2.5.2 had debug as a wide-open dependency (semver check was `*`).",
+        "Debug v4 dropped support for Node <6, thus rendering these older versions",
+        "of Koa inoperable on Node <6."
+      ]
     },
     {
       "engines": {


### PR DESCRIPTION
## CHANGELOG

* Fixed coveralls link in readme to point at master branch.

* Removed testing on Node 5 for Koa and dependent modules.

  Koa versions that supported Node 5 had an open dependency on `debug` (e.g. `"debug": "*"`). The latest major version of `debug` no longer works on Node 5 thus rendering these older versions of Koa unusable on Node 5 as well.

## INTERNAL LINKS

## NOTES
