### PR TITLE
NODE-1915 Support `response.status` naming

### DIFF
--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -102,7 +102,7 @@ function wrapCreateContext(shim, fn, fnName, context) {
   // for `context.response.status` so we only wrap the latter.
   const statusDescriptor = getInheritedPropertyDescriptor(context.response, 'status')
   if (!statusDescriptor) {
-    shim.logger.debug('Failed to find status descriptor for status on context.response')
+    shim.logger.debug('Failed to find status descriptor on context.response')
     return
   } else if (!statusDescriptor.get || !statusDescriptor.set) {
     shim.logger.debug(statusDescriptor, 'Status descriptor missing getter/setter pair')

--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -12,7 +12,10 @@ module.exports = function initialize(shim, Koa) {
   shim.setFramework(shim.KOA)
 
   shim.wrapMiddlewareMounter(Koa.prototype, 'use', wrapMiddleware)
+  shim.wrapReturn(Koa.prototype, 'createContext', wrapCreateContext)
 
+  // The application is used to handle unhandled errors in the application. We
+  // want to notice those.
   shim.wrap(Koa.prototype, 'emit', function wrapper(shim, original) {
     return function wrappedEmit(evt, err, ctx) {
       if (evt === 'error' && ctx) {
@@ -21,19 +24,6 @@ module.exports = function initialize(shim, Koa) {
       return original.apply(this, arguments)
     }
   })
-  shim.wrapReturn(Koa.prototype, 'createContext', wrapCreateContext)
-  function wrapCreateContext(shim, fn, fnName, context) {
-    context.__NR_body = context.response.body
-    Object.defineProperty(context.response, '_body', {
-      get: function getBody() {
-        return this.__NR_body
-      },
-      set: function setBody(val) {
-        shim.savePossibleTransactionName(this.req)
-        this.__NR_body = val
-      }
-    })
-  }
 }
 
 function wrapMiddleware(shim, middleware) {
@@ -69,7 +59,7 @@ function wrapMiddleware(shim, middleware) {
     return wrappedRouter
   }
 
-  // skip middleware that is already wrapped
+  // Skip middleware that are already wrapped.
   if (shim.isWrapped(middleware)) {
     return middleware
   }
@@ -80,6 +70,47 @@ function wrapMiddleware(shim, middleware) {
     req: function getReq(shim, fn, fnName, args) {
       var ctx = args[0]
       return ctx && ctx.req
+    }
+  })
+}
+
+function wrapCreateContext(shim, fn, fnName, context) {
+  // The `context.body` and `context.response.body` properties are how users set
+  // the response contents. It is roughly equivalent to `res.send()` in Express.
+  // Under the hood, these set the `_body` property on the `context.response`.
+  context.__NR_body = context.response.body
+  context.__NR_bodySet = false
+  Object.defineProperty(context.response, '_body', {
+    get: () => context.__NR_body,
+    set: function setBody(val) {
+      shim.savePossibleTransactionName(context.req)
+      context.__NR_body = val
+      context.__NR_bodySet = true
+    }
+  })
+
+  // Sometimes people just set `context.status` or `context.response.status`
+  // without setting a body. When this happens we'll want to use that as the
+  // response point to name the transaction.
+  let responseProto = context.response
+  let statusDescriptor = null
+  do {
+    statusDescriptor = Object.getOwnPropertyDescriptor(responseProto, 'status')
+    responseProto = Object.getPrototypeOf(responseProto)
+  } while (responseProto && !statusDescriptor)
+
+  if (!statusDescriptor) {
+    shim.logger.debug('Failed to find descriptor for status on context.response')
+    return
+  }
+
+  Object.defineProperty(context.response, 'status', {
+    get: () => statusDescriptor.get.call(context.response),
+    set: function setStatus(val) {
+      if (!context.__NR_bodySet) {
+        shim.savePossibleTransactionName(context.req)
+      }
+      return statusDescriptor.set.call(this, val)
     }
   })
 }

--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -75,6 +75,13 @@ function wrapMiddleware(shim, middleware) {
 }
 
 function wrapCreateContext(shim, fn, fnName, context) {
+  // Many of the properties on the `context` object are just aliases for the same
+  // property on the `request` or `response` objects. We take advantage of this
+  // by just intercepting the `request` or `response` property and don't touch
+  // the `context` property.
+  //
+  // See: https://github.com/koajs/koa/blob/master/lib/context.js#L186-L241
+
   // The `context.body` and `context.response.body` properties are how users set
   // the response contents. It is roughly equivalent to `res.send()` in Express.
   // Under the hood, these set the `_body` property on the `context.response`.
@@ -91,16 +98,14 @@ function wrapCreateContext(shim, fn, fnName, context) {
 
   // Sometimes people just set `context.status` or `context.response.status`
   // without setting a body. When this happens we'll want to use that as the
-  // response point to name the transaction.
-  let responseProto = context.response
-  let statusDescriptor = null
-  do {
-    statusDescriptor = Object.getOwnPropertyDescriptor(responseProto, 'status')
-    responseProto = Object.getPrototypeOf(responseProto)
-  } while (responseProto && !statusDescriptor)
-
+  // response point to name the transaction. `context.status` is just an alias
+  // for `context.response.status` so we only wrap the latter.
+  const statusDescriptor = getInheritedPropertyDescriptor(context.response, 'status')
   if (!statusDescriptor) {
-    shim.logger.debug('Failed to find descriptor for status on context.response')
+    shim.logger.debug('Failed to find status descriptor for status on context.response')
+    return
+  } else if (!statusDescriptor.get || !statusDescriptor.set) {
+    shim.logger.debug(statusDescriptor, 'Status descriptor missing getter/setter pair')
     return
   }
 
@@ -113,4 +118,15 @@ function wrapCreateContext(shim, fn, fnName, context) {
       return statusDescriptor.set.call(this, val)
     }
   })
+}
+
+function getInheritedPropertyDescriptor(obj, property) {
+  let proto = obj
+  let descriptor = null
+  do {
+    descriptor = Object.getOwnPropertyDescriptor(proto, property)
+    proto = Object.getPrototypeOf(proto)
+  } while (!descriptor && proto)
+
+  return descriptor
 }

--- a/tests/versioned/koa.tap.js
+++ b/tests/versioned/koa.tap.js
@@ -31,6 +31,116 @@ tap.test('Koa instrumentation', (t) => {
     done()
   })
 
+  t.test('names the transaction after the middleware that sets the body', (t) => {
+    app.use(function one(ctx, next) {
+      const tx = helper.getTransaction()
+      tx.nameState.appendPath('one-start')
+      return next().then(() => tx.nameState.appendPath('one-end'))
+    })
+
+    app.use(function two(ctx) {
+      const tx = helper.getTransaction()
+      tx.nameState.appendPath('two')
+      ctx.body = 'done'
+    })
+
+    helper.agent.on('transactionFinished', (tx) => {
+      t.equal(
+        tx.name,
+        'WebTransaction/WebFrameworkUri/Koa/GET//one-start/two',
+        'should have name without post-response name info'
+      )
+      t.end()
+    })
+
+    run()
+  })
+
+  t.test('names the transaction after the last middleware that sets the body', (t) => {
+    app.use(function one(ctx, next) {
+      const tx = helper.getTransaction()
+      tx.nameState.appendPath('one-start')
+      return next().then(() => tx.nameState.appendPath('one-end'))
+    })
+
+    app.use(function two(ctx, next) {
+      const tx = helper.getTransaction()
+      tx.nameState.appendPath('two')
+      ctx.body = 'not actually done'
+      return next()
+    })
+
+    app.use(function three(ctx) {
+      const tx = helper.getTransaction()
+      tx.nameState.appendPath('three')
+      ctx.body = 'done'
+    })
+
+    helper.agent.on('transactionFinished', (tx) => {
+      t.equal(
+        tx.name,
+        'WebTransaction/WebFrameworkUri/Koa/GET//one-start/two/three',
+        'should have name without post-response name info'
+      )
+      t.end()
+    })
+
+    run()
+  })
+
+  t.test('names the transaction off the status setting middleware', (t) => {
+    app.use(function one(ctx, next) {
+      const tx = helper.getTransaction()
+      tx.nameState.appendPath('one-start')
+      return next().then(() => tx.nameState.appendPath('one-end'))
+    })
+
+    app.use(function two(ctx) {
+      const tx = helper.getTransaction()
+      tx.nameState.appendPath('two')
+      ctx.status = 200
+    })
+
+    helper.agent.on('transactionFinished', (tx) => {
+      t.equal(
+        tx.name,
+        'WebTransaction/WebFrameworkUri/Koa/GET//one-start/two',
+        'should have name without post-response name info'
+      )
+      t.end()
+    })
+
+    run()
+  })
+
+  t.test('names the transaction when body set even if status set after', (t) => {
+    app.use(function one(ctx, next) {
+      const tx = helper.getTransaction()
+      tx.nameState.appendPath('one-start')
+      return next().then(() => tx.nameState.appendPath('one-end'))
+    })
+
+    app.use(function two(ctx) {
+      const tx = helper.getTransaction()
+      tx.nameState.appendPath('two')
+      ctx.body = 'done'
+
+      tx.nameState.appendPath('setting-status')
+      ctx.status = 200
+    })
+
+    helper.agent.on('transactionFinished', (tx) => {
+      t.equal(
+        tx.name,
+        'WebTransaction/WebFrameworkUri/Koa/GET//one-start/two',
+        'should have name without post-response name info'
+      )
+      t.end()
+    })
+
+    run()
+  })
+
   t.test('produces transaction trace with multiple middleware', (t) => {
     app.use(function one(ctx, next) {
       return next()

--- a/tests/versioned/koa.tap.js
+++ b/tests/versioned/koa.tap.js
@@ -1,37 +1,37 @@
 'use strict'
 
-var tap = require('tap')
-var utils = require('@newrelic/test-utilities')
-var http = require('http')
-var semver = require('semver')
+const tap = require('tap')
+const utils = require('@newrelic/test-utilities')
+const http = require('http')
+const semver = require('semver')
 
 utils(tap)
 
-tap.test('Koa instrumentation', function(t) {
-  var helper = null
-  var app = null
-  var server = null
+tap.test('Koa instrumentation', (t) => {
+  let helper = null
+  let app = null
+  let server = null
 
-  t.beforeEach(function(done) {
+  t.beforeEach((done) => {
     helper = utils.TestAgent.makeInstrumented()
     helper.registerInstrumentation({
       moduleName: 'koa',
       type: 'web-framework',
       onRequire: require('../../lib/instrumentation')
     })
-    var Koa = require('koa')
+    const Koa = require('koa')
     app = new Koa()
     done()
   })
 
-  t.afterEach(function(done) {
+  t.afterEach((done) => {
     server && server.close()
     app = null
     helper && helper.unload()
     done()
   })
 
-  t.test('produces transaction trace with multiple middleware', function(t) {
+  t.test('produces transaction trace with multiple middleware', (t) => {
     app.use(function one(ctx, next) {
       return next()
     })
@@ -39,14 +39,14 @@ tap.test('Koa instrumentation', function(t) {
       ctx.response.body = 'done'
     })
 
-    helper.agent.on('transactionFinished', function(tx) {
+    helper.agent.on('transactionFinished', (tx) => {
       checkSegments(t, tx)
     })
 
     run()
   })
 
-  t.test('correctly records actions interspersed among middleware', function(t) {
+  t.test('correctly records actions interspersed among middleware', (t) => {
     app.use(function one(ctx, next) {
       helper.agent.tracer.createSegment('testSegment')
       return next().then(function() {
@@ -63,7 +63,7 @@ tap.test('Koa instrumentation', function(t) {
       ctx.body = 'done'
     })
 
-    helper.agent.on('transactionFinished', function(tx) {
+    helper.agent.on('transactionFinished', (tx) => {
       // Node < 6 produces a different tx trace structure, due to differences
       // in Promise implementation.
       if (semver.lt(process.version, '6.0.0')) {
@@ -117,7 +117,7 @@ tap.test('Koa instrumentation', function(t) {
   // TRANSACTION CONTEXT IS NOT MAINTAINED BELOW NODE 8, AND REQUIRES
   // CHANGES TO THE PROMISE INSTRUMENTATION.
   //
-  // t.test('maintains transaction state between middleware', function(t) {
+  // t.test('maintains transaction state between middleware', (t) => {
   //   var tasks = []
   //   var intervalId = setInterval(function() {
   //     while (tasks.length) {
@@ -159,7 +159,7 @@ tap.test('Koa instrumentation', function(t) {
   //   run()
   // })
 
-  t.test('errors handled within middleware are not recorded', function(t) {
+  t.test('errors handled within middleware are not recorded', (t) => {
     app.use(function one(ctx, next) {
       return next().catch(function(err) {
         t.equal(err.message, 'middleware error', 'caught expected error')
@@ -172,7 +172,7 @@ tap.test('Koa instrumentation', function(t) {
       ctx.body = 'done'
     })
 
-    helper.agent.on('transactionFinished', function(tx) {
+    helper.agent.on('transactionFinished', (tx) => {
       var errors = helper.agent.errors.errors
       t.equal(errors.length, 0, 'no errors are recorded')
       checkSegments(t, tx)
@@ -181,7 +181,7 @@ tap.test('Koa instrumentation', function(t) {
     run()
   })
 
-  t.test('errors not handled by middleware are recorded', function(t) {
+  t.test('errors not handled by middleware are recorded', (t) => {
     app.use(function one(ctx, next) {
       return next().catch(function(err) {
         t.equal(err.message, 'middleware error', 'caught expected error')
@@ -193,7 +193,7 @@ tap.test('Koa instrumentation', function(t) {
       throw new Error('middleware error')
     })
 
-    helper.agent.on('transactionFinished', function(tx) {
+    helper.agent.on('transactionFinished', (tx) => {
       var errors = helper.agent.errors.errors
       t.equal(errors.length, 1, 'recorded expected number of errors')
       var error = errors[0][2]
@@ -203,7 +203,7 @@ tap.test('Koa instrumentation', function(t) {
     run()
   })
 
-  t.test('errors caught by default error listener are recorded', function(t) {
+  t.test('errors caught by default error listener are recorded', (t) => {
     app.use(function one(ctx, next) {
       return next()
     })
@@ -214,7 +214,7 @@ tap.test('Koa instrumentation', function(t) {
       t.equal(err.message, 'middleware error', 'caught expected error')
     })
 
-    helper.agent.on('transactionFinished', function(tx) {
+    helper.agent.on('transactionFinished', (tx) => {
       var errors = helper.agent.errors.errors
       t.equal(errors.length, 1, 'recorded expected number of errors')
       var error = errors[0][2]

--- a/tests/versioned/koa.tap.js
+++ b/tests/versioned/koa.tap.js
@@ -8,6 +8,8 @@ const semver = require('semver')
 utils(tap)
 
 tap.test('Koa instrumentation', (t) => {
+  t.autoend()
+
   let helper = null
   let app = null
   let server = null
@@ -32,6 +34,8 @@ tap.test('Koa instrumentation', (t) => {
   })
 
   t.test('names the transaction after the middleware that sets the body', (t) => {
+    t.plan(2)
+
     app.use(function one(ctx, next) {
       const tx = helper.getTransaction()
       tx.nameState.appendPath('one-start')
@@ -50,13 +54,14 @@ tap.test('Koa instrumentation', (t) => {
         'WebTransaction/WebFrameworkUri/Koa/GET//one-start/two',
         'should have name without post-response name info'
       )
-      t.end()
     })
 
-    run()
+    run(t)
   })
 
   t.test('names the transaction after the last middleware that sets the body', (t) => {
+    t.plan(2)
+
     app.use(function one(ctx, next) {
       const tx = helper.getTransaction()
       tx.nameState.appendPath('one-start')
@@ -82,13 +87,14 @@ tap.test('Koa instrumentation', (t) => {
         'WebTransaction/WebFrameworkUri/Koa/GET//one-start/two/three',
         'should have name without post-response name info'
       )
-      t.end()
     })
 
-    run()
+    run(t)
   })
 
   t.test('names the transaction off the status setting middleware', (t) => {
+    t.plan(4)
+
     app.use(function one(ctx, next) {
       const tx = helper.getTransaction()
       tx.nameState.appendPath('one-start')
@@ -98,7 +104,7 @@ tap.test('Koa instrumentation', (t) => {
     app.use(function two(ctx) {
       const tx = helper.getTransaction()
       tx.nameState.appendPath('two')
-      ctx.status = 200
+      ctx.status = 202
     })
 
     helper.agent.on('transactionFinished', (tx) => {
@@ -107,13 +113,17 @@ tap.test('Koa instrumentation', (t) => {
         'WebTransaction/WebFrameworkUri/Koa/GET//one-start/two',
         'should have name without post-response name info'
       )
-      t.end()
     })
 
-    run()
+    run(t, 'Accepted', (err, res) => {
+      t.error(err)
+      t.equal(res.statusCode, 202, 'should not interfere with status code setting')
+    })
   })
 
   t.test('names the transaction when body set even if status set after', (t) => {
+    t.plan(4)
+
     app.use(function one(ctx, next) {
       const tx = helper.getTransaction()
       tx.nameState.appendPath('one-start')
@@ -126,7 +136,7 @@ tap.test('Koa instrumentation', (t) => {
       ctx.body = 'done'
 
       tx.nameState.appendPath('setting-status')
-      ctx.status = 200
+      ctx.status = 202
     })
 
     helper.agent.on('transactionFinished', (tx) => {
@@ -135,13 +145,17 @@ tap.test('Koa instrumentation', (t) => {
         'WebTransaction/WebFrameworkUri/Koa/GET//one-start/two',
         'should have name without post-response name info'
       )
-      t.end()
     })
 
-    run()
+    run(t, (err, res) => {
+      t.error(err)
+      t.equal(res.statusCode, 202, 'should not interfere with status code setting')
+    })
   })
 
   t.test('produces transaction trace with multiple middleware', (t) => {
+    t.plan(2)
+
     app.use(function one(ctx, next) {
       return next()
     })
@@ -153,10 +167,12 @@ tap.test('Koa instrumentation', (t) => {
       checkSegments(t, tx)
     })
 
-    run()
+    run(t)
   })
 
   t.test('correctly records actions interspersed among middleware', (t) => {
+    t.plan(2)
+
     app.use(function one(ctx, next) {
       helper.agent.tracer.createSegment('testSegment')
       return next().then(function() {
@@ -217,10 +233,9 @@ tap.test('Koa instrumentation', (t) => {
           }
         ])
       }
-      t.end()
     })
 
-    run()
+    run(t)
   })
 
   // THIS TEST WILL ONLY PASS IN CASES WHEN { await_support: true }.
@@ -266,10 +281,12 @@ tap.test('Koa instrumentation', (t) => {
   //     checkSegments(t, txn)
   //   })
 
-  //   run()
+  //   run(t)
   // })
 
   t.test('errors handled within middleware are not recorded', (t) => {
+    t.plan(4)
+
     app.use(function one(ctx, next) {
       return next().catch(function(err) {
         t.equal(err.message, 'middleware error', 'caught expected error')
@@ -288,10 +305,12 @@ tap.test('Koa instrumentation', (t) => {
       checkSegments(t, tx)
     })
 
-    run()
+    run(t, 'handled error')
   })
 
   t.test('errors not handled by middleware are recorded', (t) => {
+    t.plan(5)
+
     app.use(function one(ctx, next) {
       return next().catch(function(err) {
         t.equal(err.message, 'middleware error', 'caught expected error')
@@ -310,10 +329,12 @@ tap.test('Koa instrumentation', (t) => {
       t.equal(error, 'middleware error', 'recorded expected error')
       checkSegments(t, tx)
     })
-    run()
+    run(t, 'error is not actually handled')
   })
 
   t.test('errors caught by default error listener are recorded', (t) => {
+    t.plan(5)
+
     app.use(function one(ctx, next) {
       return next()
     })
@@ -331,18 +352,30 @@ tap.test('Koa instrumentation', (t) => {
       t.equal(error, 'middleware error', 'recorded expected error')
       checkSegments(t, tx)
     })
-    run()
+    run(t, 'Internal Server Error')
   })
 
-  t.autoend()
+  function run(t, expected, cb) {
+    if (typeof expected !== 'string') {
+      // run(t [, cb])
+      cb = expected
+      expected = 'done'
+    }
 
-  function run() {
-    server = app.listen(0, function() {
-      http.get({port: server.address().port}, function(res) {
-        if (res.body) {
-          t.equal(res.body, 'done')
-        }
-      }).end()
+    server = app.listen(0, () => {
+      http.get({port: server.address().port}, (res) => {
+        let body = ''
+        res.on('data', (data) => body += data.toString('utf8'))
+        res.on('error', (err) => cb && cb(err))
+        res.on('end', () => {
+          if (expected) {
+            t.equal(body, expected, 'should send expected response')
+          }
+          if (cb) {
+            cb(null, res)
+          }
+        })
+      })
     })
   }
 })
@@ -363,5 +396,4 @@ function checkSegments(t, tx) {
     }],
     'segments have expected names'
   )
-  t.end()
 }


### PR DESCRIPTION
## CHANGELOG

* Adds support for naming transactions without setting the `context.body` property.

## INTERNAL LINKS

## NOTES
