### PR TITLE
NODE-2044 Add allowedMethods coverage

### DIFF
--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -69,6 +69,7 @@ function wrapMiddleware(shim, middleware) {
   return shim.recordMiddleware(middleware, {
     type: shim.MIDDLEWARE,
     promise: true,
+    appendPath: false,
     req: function getReq(shim, fn, fnName, args) {
       return args[0] && args[0].req
     }

--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -1,5 +1,8 @@
 'use strict'
 
+// Toggles whether to append current path to transaction name,
+// depending on if koa-router is being used.
+let hasRouter = null
 
 module.exports = function initialize(shim, Koa) {
   if (!shim || !Koa || Object.keys(Koa.prototype).length > 1) {
@@ -28,6 +31,9 @@ module.exports = function initialize(shim, Koa) {
 
 function wrapMiddleware(shim, middleware) {
   const router = middleware.router
+  if (hasRouter === null) {
+    hasRouter = !!router
+  }
 
   if (router && router.stack && router.stack.length) {
     const stack = router.stack
@@ -69,7 +75,7 @@ function wrapMiddleware(shim, middleware) {
   return shim.recordMiddleware(middleware, {
     type: shim.MIDDLEWARE,
     promise: true,
-    appendPath: false,
+    appendPath: !hasRouter,
     req: function getReq(shim, fn, fnName, args) {
       return args[0] && args[0].req
     }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint *.js lib tests"
   },
   "author": "New Relic Node.js agent team <nodejs@newrelic.com>",
-  "license": "LicenseRef-LICENSE",
+  "license": "SEE LICENSE IN LICENSE",
   "devDependencies": {
     "@newrelic/test-utilities": "^3.0.0",
     "coveralls": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "methods": "^1.1.2"
   },
   "peerDependencies": {
-    "newrelic": ">=3.3.1"
+    "newrelic": ">=5.7.0"
   }
 }

--- a/tests/versioned/koa-router.tap.js
+++ b/tests/versioned/koa-router.tap.js
@@ -20,7 +20,7 @@ tap.test('koa-router instrumentation', (t) => {
     paramMiddlewareName = 'Nodejs/Middleware/Koa/<anonymous>//:first'
   }
 
-  t.beforeEach((done) => {
+  function testSetup(done) {
     helper = utils.TestAgent.makeInstrumented()
     helper.registerInstrumentation({
       moduleName: 'koa',
@@ -37,564 +37,729 @@ tap.test('koa-router instrumentation', (t) => {
     Router = require('koa-router')
     router = new Router()
     done()
-  })
+  }
 
-  t.afterEach((done) => {
+  function tearDown(done) {
     server.close()
     app = null
     router = null
     Router = null
     helper && helper.unload()
     done()
-  })
+  }
 
-  t.test('should name and produce segments for matched path', (t) => {
-    router.get('/:first', function firstMiddleware(ctx) {
-      ctx.body = 'first'
-    })
-    app.use(router.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
-          children: [{
-            name: 'Koa/Router: /',
-            children: [{
-              name: 'Nodejs/Middleware/Koa/firstMiddleware//:first'
-            }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:first',
-        'transaction should be named after the matched path'
-      )
-      t.end()
-    })
-    run()
-  })
+  t.test('with single router', (t) => {
+    t.beforeEach((done) => testSetup(done))
+    t.afterEach((done) => tearDown(done))
+    t.autoend()
 
-  t.test('should name and produce segments for matched regex path', (t) => {
-    router.get(/.*rst$/, function firstMiddleware(ctx) {
-      ctx.body = 'first'
-    })
-    app.use(router.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//.*rst$',
-          children: [{
-            name: 'Koa/Router: /',
+    t.test('should name and produce segments for matched path', (t) => {
+      router.get('/:first', function firstMiddleware(ctx) {
+        ctx.body = 'first'
+      })
+      app.use(router.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
             children: [{
-              name: 'Nodejs/Middleware/Koa/firstMiddleware//.*rst$/'
-            }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//.*rst$',
-        'transaction should be named after the matched regex pattern'
-      )
-      t.end()
-    })
-    run('/first')
-  })
-
-  t.test('should name and produce segments for matched regex path', (t) => {
-    router.get('/:first/(.*)', function firstMiddleware(ctx) {
-      ctx.body = 'first'
-    })
-    app.use(router.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first/(.*)',
-          children: [{
-            name: 'Koa/Router: /',
-            children: [{
-              name: 'Nodejs/Middleware/Koa/firstMiddleware//:first/(.*)'
-            }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:first/(.*)',
-        'transaction should be named after the matched regex path'
-      )
-      t.end()
-    })
-    run('/123/456')
-  })
-
-  t.test('should name and produce segments with router paramware', (t) => {
-    router.param('first', function firstParamware(id, ctx, next) {
-      ctx.body = 'first'
-      return next()
-    })
-    router.get('/:first', function firstMiddleware(ctx, next) {
-      return next()
-    })
-    app.use(router.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
-          children: [{
-            name: 'Koa/Router: /',
-            children: [{
-              name: paramMiddlewareName,
+              name: 'Koa/Router: /',
               children: [{
-                name: 'Nodejs/Middleware/Koa/firstParamware//[param handler :first]',
+                name: 'Nodejs/Middleware/Koa/firstMiddleware//:first'
+              }]
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:first',
+          'transaction should be named after the matched path'
+        )
+        t.end()
+      })
+      run()
+    })
+
+    t.test('should name and produce segments for matched regex path', (t) => {
+      router.get(/.*rst$/, function firstMiddleware(ctx) {
+        ctx.body = 'first'
+      })
+      app.use(router.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//.*rst$',
+            children: [{
+              name: 'Koa/Router: /',
+              children: [{
+                name: 'Nodejs/Middleware/Koa/firstMiddleware//.*rst$/'
+              }]
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//.*rst$',
+          'transaction should be named after the matched regex pattern'
+        )
+        t.end()
+      })
+      run('/first')
+    })
+
+    t.test('should name and produce segments for matched regex path', (t) => {
+      router.get('/:first/(.*)', function firstMiddleware(ctx) {
+        ctx.body = 'first'
+      })
+      app.use(router.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first/(.*)',
+            children: [{
+              name: 'Koa/Router: /',
+              children: [{
+                name: 'Nodejs/Middleware/Koa/firstMiddleware//:first/(.*)'
+              }]
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:first/(.*)',
+          'transaction should be named after the matched regex path'
+        )
+        t.end()
+      })
+      run('/123/456')
+    })
+
+    t.test('should name and produce segments with router paramware', (t) => {
+      router.param('first', function firstParamware(id, ctx, next) {
+        ctx.body = 'first'
+        return next()
+      })
+      router.get('/:first', function firstMiddleware(ctx, next) {
+        return next()
+      })
+      app.use(router.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
+            children: [{
+              name: 'Koa/Router: /',
+              children: [{
+                name: paramMiddlewareName,
+                children: [{
+                  name: 'Nodejs/Middleware/Koa/firstParamware//[param handler :first]',
+                  children: [{
+                    name: 'Nodejs/Middleware/Koa/firstMiddleware//:first'
+                  }]
+                }]
+              }]
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:first',
+          'transaction should be named after the matched path'
+        )
+        t.end()
+      })
+      run()
+    })
+
+    t.test('should name transaction after matched path with erroring parameware', (t) => {
+      router.param('first', function firstParamware() {
+        throw new Error('wrong param')
+      })
+      router.get('/:first', function firstMiddleware() {})
+
+      app.use(router.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
+            children: [{
+              name: 'Koa/Router: /',
+              children: [{
+                name: paramMiddlewareName,
+                children: [{
+                  name: 'Nodejs/Middleware/Koa/firstParamware//[param handler :first]'
+                }]
+              }]
+            }]
+          }],
+          'should have expected segments'
+        )
+        const errors = helper.agent.errors.errors
+        t.equal(errors.length, 1, 'the error has been recorded')
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:first',
+          'transaction should be named after the matched path'
+        )
+        t.end()
+      })
+      run()
+    })
+
+    t.test('should name the transaction after the last matched path (layer)', (t) => {
+      router.get('/:first', function firstMiddleware(ctx, next) {
+        ctx.body = 'first'
+        return next().then(function someMoreContent() {
+          ctx.body = 'first'
+        })
+      })
+      router.get('/:second', function secondMiddleware(ctx) {
+        ctx.body += ' second'
+      })
+
+      app.use(router.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:second',
+            children: [{
+              name: 'Koa/Router: /',
+              children: [{
+                name: 'Nodejs/Middleware/Koa/firstMiddleware//:first',
+                children: [{
+                  name: 'Nodejs/Middleware/Koa/secondMiddleware//:second'
+                }]
+              }]
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:second',
+          'transaction should be named after the matched path'
+        )
+        t.end()
+      })
+      run()
+    })
+
+    t.test('tx name should not be named after error handling middleware', (t) => {
+      app.use(function errorHandler(ctx, next) {
+        return next().catch((err) => {
+          ctx.body = { err: err.message }
+        })
+      })
+
+      router.get('/:first', function firstMiddleware(ctx) {
+        ctx.throw(400, '☃')
+      })
+
+      app.use(router.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
+            children: [{
+              name: 'Nodejs/Middleware/Koa/errorHandler',
+              children: [{
+                name: 'Koa/Router: /',
                 children: [{
                   name: 'Nodejs/Middleware/Koa/firstMiddleware//:first'
                 }]
               }]
             }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:first',
-        'transaction should be named after the matched path'
-      )
-      t.end()
+          }],
+          'should have expected segments'
+        )
+        const errors = helper.agent.errors.errors
+        t.equal(errors.length, 0, 'should not record error')
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:first',
+          'transaction should be named after the matched layer path'
+        )
+        t.end()
+      })
+      run()
     })
-    run()
-  })
 
-  t.test('should name transaction after matched path with erroring parameware', (t) => {
-    router.param('first', function firstParamware() {
-      throw new Error('wrong param')
-    })
-    router.get('/:first', function firstMiddleware() {})
+    t.test('transaction name should not be affected by unhandled error', (t) => {
+      app.use(function errorHandler(ctx, next) {
+        return next()
+      })
 
-    app.use(router.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
-          children: [{
-            name: 'Koa/Router: /',
+      router.get('/:first', function firstMiddleware(ctx) {
+        ctx.throw(400, '☃')
+      })
+
+      app.use(router.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
             children: [{
-              name: paramMiddlewareName,
+              name: 'Nodejs/Middleware/Koa/errorHandler',
               children: [{
-                name: 'Nodejs/Middleware/Koa/firstParamware//[param handler :first]'
+                name: 'Koa/Router: /',
+                children: [{
+                  name: 'Nodejs/Middleware/Koa/firstMiddleware//:first'
+                }]
               }]
             }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      const errors = helper.agent.errors.errors
-      t.equal(errors.length, 1, 'the error has been recorded')
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:first',
-        'transaction should be named after the matched path'
-      )
-      t.end()
+          }],
+          'should have expected segments'
+        )
+        const errors = helper.agent.errors.errors
+        t.equal(errors.length, 1, 'error should be recorded')
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:first',
+          'transaction should be named after the matched layer path'
+        )
+        t.end()
+      })
+      run()
     })
-    run()
+
+    t.test('should name tx after route declarations with supported http methods', (t) => {
+      // This will register the same middleware (i.e. secondMiddleware)
+      // under both the /:first and /:second routes. Use does not register middleware
+      // w/ supported methods they cannot handle routes.
+      router.use(['/:first', '/:second'], function secondMiddleware(ctx, next) {
+        ctx.body += ' second'
+        return next()
+      })
+      router.get('/:second', function terminalMiddleware(ctx) {
+        ctx.body = ' second'
+      })
+      app.use(router.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:second',
+            children: [{
+              name: 'Koa/Router: /',
+              children: [{
+                name: 'Nodejs/Middleware/Koa/secondMiddleware//:first',
+                children: [{
+                  name: 'Nodejs/Middleware/Koa/secondMiddleware//:second',
+                  children: [{
+                    name: 'Nodejs/Middleware/Koa/terminalMiddleware//:second'
+                  }]
+                }]
+              }]
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:second',
+          'transaction should be named after the last matched path'
+        )
+        t.end()
+      })
+      run()
+    })
+
+    t.test('names transaction (not found) with array of paths and no handler', (t) => {
+      // This will register the same middleware (i.e. secondMiddleware)
+      // under both the /:first and /:second routes.
+      router.use(['/:first', '/:second'], function secondMiddleware(ctx, next) {
+        ctx.body += ' second'
+        return next()
+      })
+      app.use(router.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET/(not found)',
+            children: [{
+              name: 'Koa/Router: /'
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET/(not found)',
+          'transaction should be named (not found)'
+        )
+        t.end()
+      })
+      run()
+    })
   })
 
-  t.test('should name the transaction after the last matched path (layer)', (t) => {
-    router.get('/:first', function firstMiddleware(ctx, next) {
-      ctx.body = 'first'
-      return next().then(function someMoreContent() {
+  t.test('using multipler routers', (t) => {
+    t.beforeEach((done) => testSetup(done))
+    t.afterEach((done) => tearDown(done))
+    t.autoend()
+
+    t.test('should name transaction after last route for identical matches', (t) => {
+      Router = require('koa-router')
+      const router2 = new Router()
+      router.get('/:first', function firstMiddleware(ctx, next) {
+        ctx.body = 'first'
+        return next()
+      })
+
+      router2.get('/:second', function secondMiddleware(ctx) {
+        ctx.body += ' second'
+      })
+      app.use(router.routes())
+      app.use(router2.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        // NOTE: due to an implementation detail in koa-compose,
+        // sequential middleware will show up as nested. This is due to
+        // the dispatch function blocking its returned promise on the
+        // resolution of a recursively returned promise.
+        // https://github.com/koajs/compose/blob/e754ca3c13e9248b3f453d98ea0b618e09578e2d/index.js#L42-L44
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:second',
+            children: [{
+              name: 'Koa/Router: /',
+              children: [{
+                name: 'Nodejs/Middleware/Koa/firstMiddleware//:first',
+                children: [{
+                  name: 'Koa/Router: /',
+                  children: [{
+                    name: 'Nodejs/Middleware/Koa/secondMiddleware//:second'
+                  }]
+                }]
+              }]
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:second',
+          'transaction should be named after the most specific matched path'
+        )
+        t.end()
+      })
+      run()
+    })
+
+    t.test('should name tx after last matched route even if body not set', (t) => {
+      Router = require('koa-router')
+      const router2 = new Router()
+      router.get('/first', function firstMiddleware(ctx, next) {
+        ctx.body = 'first'
+        return next()
+      })
+
+      router2.get('/:second', function secondMiddleware() {})
+      app.use(router.routes())
+      app.use(router2.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        // NOTE: due to an implementation detail in koa-compose,
+        // sequential middleware will show up as nested. This is due to
+        // the dispatch function blocking its returned promise on the
+        // resolution of a recursively returned promise.
+        // https://github.com/koajs/compose/blob/e754ca3c13e9248b3f453d98ea0b618e09578e2d/index.js#L42-L44
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:second',
+            children: [{
+              name: 'Koa/Router: /',
+              children: [{
+                name: 'Nodejs/Middleware/Koa/firstMiddleware//first',
+                children: [{
+                  name: 'Koa/Router: /',
+                  children: [{
+                    name: 'Nodejs/Middleware/Koa/secondMiddleware//:second'
+                  }]
+                }]
+              }]
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:second',
+          'transaction should be named after the last matched path'
+        )
+        t.end()
+      })
+      run('/first')
+    })
+  })
+
+  t.test('using nested or prefixed routers', (t) => {
+    t.beforeEach((done) => testSetup(done))
+    t.afterEach((done) => tearDown(done))
+    t.autoend()
+
+    t.test('should name after most last matched path', (t) => {
+      var router2 = new Router()
+      router2.get('/:second', function secondMiddleware(ctx) {
+        ctx.body = ' second'
+      })
+      router.use('/:first', router2.routes())
+      app.use(router.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first/:second',
+            children: [{
+              name: 'Koa/Router: /',
+              children: [{
+                name: 'Nodejs/Middleware/Koa/secondMiddleware//:first/:second'
+              }]
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:first/:second',
+          'transaction should be named after the last matched path'
+        )
+        t.end()
+      })
+      run('/123/456/')
+    })
+
+    t.test('app-level middleware should not rename tx from matched path', (t) => {
+      app.use(function appLevelMiddleware(ctx, next) {
+        return next().then(() => {
+          ctx.body = 'do not want this to set the name'
+        })
+      })
+
+      const nestedRouter = new Router()
+      nestedRouter.get('/:second', function terminalMiddleware(ctx) {
+        ctx.body = 'this is a test'
+      })
+      nestedRouter.get('/second', function secondMiddleware(ctx) {
+        ctx.body = 'want this to set the name'
+      })
+      router.use('/:first', nestedRouter.routes())
+      app.use(router.routes())
+
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first/second',
+            children: [{
+              name: 'Nodejs/Middleware/Koa/appLevelMiddleware',
+              children: [{
+                name: 'Koa/Router: /',
+                children: [{
+                  name: 'Nodejs/Middleware/Koa/terminalMiddleware//:first/:second'
+                }]
+              }]
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:first/second',
+          'should be named after last matched route'
+        )
+        t.end()
+      })
+      run('/123/second')
+    })
+
+    t.test('app-level middleware should not rename tx from matched prefix path', (t) => {
+      app.use(function appLevelMiddleware(ctx, next) {
+        return next().then(() => {
+          ctx.body = 'do not want this to set the name'
+        })
+      })
+
+      router.get('/:second', function terminalMiddleware(ctx) {
+        ctx.body = 'this is a test'
+      })
+      router.get('/second', function secondMiddleware(ctx) {
+        ctx.body = 'want this to set the name'
+      })
+      router.prefix('/:first')
+      app.use(router.routes())
+
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first/second',
+            children: [{
+              name: 'Nodejs/Middleware/Koa/appLevelMiddleware',
+              children: [{
+                name: 'Koa/Router: /',
+                children: [{
+                  name: 'Nodejs/Middleware/Koa/terminalMiddleware//:first/:second'
+                }]
+              }]
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:first/second',
+          'should be named after the last matched path'
+        )
+        t.end()
+      })
+      run('/123/second')
+    })
+  })
+
+  t.test('using allowedMethods', (t) => {
+    t.beforeEach((done) => testSetup(done))
+    t.afterEach((done) => tearDown(done))
+    t.autoend()
+
+    t.test('should name transaction after `method now allowed` message', (t) => {
+      router.post('/:first', function firstMiddleware() {})
+      app.use(router.routes())
+      app.use(router.allowedMethods({throw: true}))
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)'
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
+          'transaction should be named after corresponding status code message'
+        )
+        const errors = helper.agent.errors.errors
+        t.equal(errors.length, 1, 'the error has been recorded')
+        t.end()
+      })
+      run()
+    })
+
+    t.test('should name transaction after `not implemented` message', (t) => {
+      router = new Router({ methods: ['POST'] })
+      router.post('/:first', function firstMiddleware() {})
+      app.use(router.routes())
+      app.use(router.allowedMethods())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET/(not implemented)'
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET/(not implemented)',
+          'transaction should be named after corresponding status code message'
+        )
+        // TODO: this seems wrong before of no {throw: true}
+        const errors = helper.agent.errors.errors
+        t.equal(errors.length, 1, 'the error has been recorded')
+        t.end()
+      })
+      run()
+    })
+
+    t.test('should name and produce segments for existing matched path', (t) => {
+      router = new Router({ methods: ['GET'] })
+      router.get('/:first', function firstMiddleware(ctx) {
         ctx.body = 'first'
       })
-    })
-    router.get('/:second', function secondMiddleware(ctx) {
-      ctx.body += ' second'
-    })
-
-    app.use(router.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:second',
-          children: [{
-            name: 'Koa/Router: /',
-            children: [{
-              name: 'Nodejs/Middleware/Koa/firstMiddleware//:first',
-              children: [{
-                name: 'Nodejs/Middleware/Koa/secondMiddleware//:second'
-              }]
-            }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:second',
-        'transaction should be named after the matched path'
-      )
-      t.end()
-    })
-    run()
-  })
-
-  t.test('transaction name should not be named after error handling middleware', (t) => {
-    app.use(function errorHandler(ctx, next) {
-      return next().catch((err) => {
-        ctx.body = { err: err.message }
-      })
-    })
-
-    router.get('/:first', function firstMiddleware(ctx) {
-      ctx.throw(400, '☃')
-    })
-
-    app.use(router.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
-          children: [{
-            name: 'Nodejs/Middleware/Koa/errorHandler',
+      app.use(router.routes())
+      app.use(router.allowedMethods())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
             children: [{
               name: 'Koa/Router: /',
               children: [{
                 name: 'Nodejs/Middleware/Koa/firstMiddleware//:first'
               }]
             }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      const errors = helper.agent.errors.errors
-      t.equal(errors.length, 0, 'should not record error')
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:first',
-        'transaction should be named after the matched layer path'
-      )
-      t.end()
-    })
-    run()
-  })
-
-  t.test('transaction name should not be affected by unhandled error', (t) => {
-    app.use(function errorHandler(ctx, next) {
-      return next()
-    })
-
-    router.get('/:first', function firstMiddleware(ctx) {
-      ctx.throw(400, '☃')
-    })
-
-    app.use(router.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
-          children: [{
-            name: 'Nodejs/Middleware/Koa/errorHandler',
-            children: [{
-              name: 'Koa/Router: /',
-              children: [{
-                name: 'Nodejs/Middleware/Koa/firstMiddleware//:first'
-              }]
-            }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      const errors = helper.agent.errors.errors
-      t.equal(errors.length, 1, 'error should be recorded')
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:first',
-        'transaction should be named after the matched layer path'
-      )
-      t.end()
-    })
-    run()
-  })
-
-  t.test('should name transaction after last route for identical matches', (t) => {
-    Router = require('koa-router')
-    const router2 = new Router()
-    router.get('/:first', function firstMiddleware(ctx, next) {
-      ctx.body = 'first'
-      return next()
-    })
-
-    router2.get('/:second', function secondMiddleware(ctx) {
-      ctx.body += ' second'
-    })
-    app.use(router.routes())
-    app.use(router2.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      // NOTE: due to an implementation detail in koa-compose,
-      // sequential middleware will show up as nested. This is due to
-      // the dispatch function blocking its returned promise on the
-      // resolution of a recursively returned promise.
-      // https://github.com/koajs/compose/blob/e754ca3c13e9248b3f453d98ea0b618e09578e2d/index.js#L42-L44
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:second',
-          children: [{
-            name: 'Koa/Router: /',
-            children: [{
-              name: 'Nodejs/Middleware/Koa/firstMiddleware//:first',
-              children: [{
-                name: 'Koa/Router: /',
-                children: [{
-                  name: 'Nodejs/Middleware/Koa/secondMiddleware//:second'
-                }]
-              }]
-            }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:second',
-        'transaction should be named after the most specific matched path'
-      )
-      t.end()
-    })
-    run()
-  })
-
-  t.test('should name tx after last matched route even if body not set', (t) => {
-    Router = require('koa-router')
-    const router2 = new Router()
-    router.get('/first', function firstMiddleware(ctx, next) {
-      ctx.body = 'first'
-      return next()
-    })
-
-    router2.get('/:second', function secondMiddleware() {})
-    app.use(router.routes())
-    app.use(router2.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      // NOTE: due to an implementation detail in koa-compose,
-      // sequential middleware will show up as nested. This is due to
-      // the dispatch function blocking its returned promise on the
-      // resolution of a recursively returned promise.
-      // https://github.com/koajs/compose/blob/e754ca3c13e9248b3f453d98ea0b618e09578e2d/index.js#L42-L44
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:second',
-          children: [{
-            name: 'Koa/Router: /',
-            children: [{
-              name: 'Nodejs/Middleware/Koa/firstMiddleware//first',
-              children: [{
-                name: 'Koa/Router: /',
-                children: [{
-                  name: 'Nodejs/Middleware/Koa/secondMiddleware//:second'
-                }]
-              }]
-            }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:second',
-        'transaction should be named after the last matched path'
-      )
-      t.end()
-    })
-    run('/first')
-  })
-
-  t.test('should name after most last matched path in nested router', (t) => {
-    var router2 = new Router()
-    router2.get('/:second', function secondMiddleware(ctx) {
-      ctx.body = ' second'
-    })
-    router.use('/:first', router2.routes())
-    app.use(router.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first/:second',
-          children: [{
-            name: 'Koa/Router: /',
-            children: [{
-              name: 'Nodejs/Middleware/Koa/secondMiddleware//:first/:second'
-            }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:first/:second',
-        'transaction should be named after the last matched path'
-      )
-      t.end()
-    })
-    run('/123/456/')
-  })
-
-  t.test('should name tx after route declarations with supported http methods', (t) => {
-    // This will register the same middleware (i.e. secondMiddleware)
-    // under both the /:first and /:second routes. Use does not register middleware
-    // w/ supported methods they cannot handle routes.
-    router.use(['/:first', '/:second'], function secondMiddleware(ctx, next) {
-      ctx.body += ' second'
-      return next()
-    })
-    router.get('/:second', function terminalMiddleware(ctx) {
-      ctx.body = ' second'
-    })
-    app.use(router.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:second',
-          children: [{
-            name: 'Koa/Router: /',
-            children: [{
-              name: 'Nodejs/Middleware/Koa/secondMiddleware//:first',
-              children: [{
-                name: 'Nodejs/Middleware/Koa/secondMiddleware//:second',
-                children: [{
-                  name: 'Nodejs/Middleware/Koa/terminalMiddleware//:second'
-                }]
-              }]
-            }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:second',
-        'transaction should be named after the last matched path'
-      )
-      t.end()
-    })
-    run()
-  })
-
-  t.test('names transaction (not found) with array of paths and no handler', (t) => {
-    // This will register the same middleware (i.e. secondMiddleware)
-    // under both the /:first and /:second routes.
-    router.use(['/:first', '/:second'], function secondMiddleware(ctx, next) {
-      ctx.body += ' second'
-      return next()
-    })
-    app.use(router.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET/(not found)',
-          children: [{
-            name: 'Koa/Router: /'
-          }]
-        }],
-        'should have expected segments'
-      )
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET/(not found)',
-        'transaction should be named (not found)'
-      )
-      t.end()
-    })
-    run()
-  })
-
-  t.test('app-level middleware should not rename tx from nested router', (t) => {
-    app.use(function appLevelMiddleware(ctx, next) {
-      return next().then(() => {
-        ctx.body = 'do not want this to set the name'
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:first',
+          'transaction should be named after the matched path'
+        )
+        t.end()
       })
+      run()
     })
 
-    const nestedRouter = new Router()
-    nestedRouter.get('/:second', function terminalMiddleware(ctx) {
-      ctx.body = 'this is a test'
-    })
-    nestedRouter.get('/second', function secondMiddleware(ctx) {
-      ctx.body = 'want this to set the name'
-    })
-    router.use('/:first', nestedRouter.routes())
-    app.use(router.routes())
-
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first/second',
-          children: [{
-            name: 'Nodejs/Middleware/Koa/appLevelMiddleware',
-            children: [{
-              name: 'Koa/Router: /',
-              children: [{
-                name: 'Nodejs/Middleware/Koa/terminalMiddleware//:first/:second'
-              }]
-            }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:first/second',
-        'should be named after last matched route'
-      )
-      t.end()
-    })
-    run('/123/second')
-  })
-
-  t.test('app-level middleware should not rename tx from prefixed router', (t) => {
-    app.use(function appLevelMiddleware(ctx, next) {
-      return next().then(() => {
-        ctx.body = 'do not want this to set the name'
+    t.test('should name tx from status code message', (t) => {
+      // This will register the same middleware (i.e. secondMiddleware)
+      // under both the /:first and /:second routes. Use does not register middleware
+      // w/ supported methods they cannot handle routes.
+      router.use(['/:first', '/:second'], function secondMiddleware(ctx, next) {
+        ctx.body += ' second'
+        return next()
       })
+      router.post('/:second', function terminalMiddleware(ctx) {
+        ctx.body = ' second'
+      })
+      app.use(router.routes())
+      app.use(router.allowedMethods({throw: true}))
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)'
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
+          'transaction should be named after the last matched path'
+        )
+        t.end()
+      })
+      run()
     })
 
-    router.get('/:second', function terminalMiddleware(ctx) {
-      ctx.body = 'this is a test'
-    })
-    router.get('/second', function secondMiddleware(ctx) {
-      ctx.body = 'want this to set the name'
-    })
-    router.prefix('/:first')
-    app.use(router.routes())
+    t.test('should name tx after `method not allowed` with prefixed router', (t) => {
+      app.use(function appLevelMiddleware(ctx, next) {
+        return next().then(() => {
+          ctx.body = 'should not set the same'
+        })
+      })
+      router.post('/second', function secondMiddleware(ctx) {
+        ctx.body = 'should not set the name'
+      })
+      router.prefix('/:first')
+      app.use(router.routes())
+      app.use(router.allowedMethods())
 
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first/second',
-          children: [{
-            name: 'Nodejs/Middleware/Koa/appLevelMiddleware',
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
             children: [{
-              name: 'Koa/Router: /',
-              children: [{
-                name: 'Nodejs/Middleware/Koa/terminalMiddleware//:first/:second'
-              }]
+              name: 'Nodejs/Middleware/Koa/appLevelMiddleware'
             }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:first/second',
-        'should be named after the last matched path'
-      )
-      t.end()
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
+          'should be named after the last matched path'
+        )
+        t.end()
+      })
+      run('/123/second')
     })
-    run('/123/second')
   })
 
   t.autoend()

--- a/tests/versioned/koa-router.tap.js
+++ b/tests/versioned/koa-router.tap.js
@@ -760,6 +760,43 @@ tap.test('koa-router instrumentation', (t) => {
       })
       run('/123/second')
     })
+
+    t.test('error handler normalizes tx name if body is reset', (t) => {
+      app.use(function errorHandler(ctx, next) {
+        return next().catch(() => {
+          ctx.body = { msg: 'error is handled' }
+        })
+      })
+
+      const nestedRouter = new Router()
+      nestedRouter.post('/:second', function terminalMiddleware(ctx) {
+        ctx.body = 'would want this to set name if verb were correct'
+      })
+      router.use('/:first', nestedRouter.routes(), nestedRouter.allowedMethods())
+      app.use(router.routes())
+      app.use(router.allowedMethods({throw: true}))
+
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/NormalizedUri/*',
+            children: [{
+              name: 'Nodejs/Middleware/Koa/errorHandler'
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/NormalizedUri/*',
+          'should have normalized transaction name'
+        )
+        const errors = helper.agent.errors.errors
+        t.equal(errors.length, 0, 'error should not be recorded')
+        t.end()
+      })
+      run('/123/456')
+    })
   })
 
   t.autoend()


### PR DESCRIPTION
## CHANGELOG

* Added tests for various koa-router `allowedMethods` use cases.

## INTERNAL LINKS

## NOTES

~This should be merged after #20 (diff is big because this is based off of that branch).~
~Travis blocked by https://source.datanerd.us/NodeJS-agent/nodejs_agent/pull/1733 (and a release ).~
