### PR TITLE
NODE-2044 Add allowedMethods coverage and separate koa router instrumentation logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ typings/
 # dotenv environment variables file
 .env
 
+# VS Code configuration
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ typings/
 
 # VS Code configuration
 .vscode
+
+# Mac folder attributes
+.DS_Store

--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -30,42 +30,41 @@ module.exports = function initialize(shim, Koa) {
 }
 
 function wrapMiddleware(shim, middleware) {
-  const router = middleware.router
   if (hasRouter === null) {
-    hasRouter = !!router
+    hasRouter = !!middleware.router
   }
 
-  if (router && router.stack && router.stack.length) {
-    const stack = router.stack
-    for (let i = 0; i < stack.length; ++i) {
-      const layer = stack[i]
-      const spec = {
-        route: layer.path,
-        type: shim.MIDDLEWARE,
-        next: shim.LAST,
-        promise: true,
-        appendPath: false,
-        req: function getReq(shim, fn, fnName, args) {
-          return args[0] && args[0].req
-        }
-      }
-      layer.stack = layer.stack.map(function wrapLayerMiddleware(m) {
-        return shim.recordMiddleware(m, spec)
-      })
-    }
-    const wrappedRouter = shim.recordMiddleware(middleware, {
-      type: shim.ROUTER,
-      promise: true,
-      appendPath: false,
-      req: function getReq(shim, fn, fnName, args) {
-        return args[0] && args[0].req
-      }
-    })
-    Object.keys(router).forEach(function copyKeys(k) {
-      wrappedRouter[k] = router[k]
-    })
-    return wrappedRouter
-  }
+  // if (router && router.stack && router.stack.length) {
+  //   const stack = router.stack
+  //   for (let i = 0; i < stack.length; ++i) {
+  //     const layer = stack[i]
+  //     const spec = {
+  //       route: layer.path,
+  //       type: shim.MIDDLEWARE,
+  //       next: shim.LAST,
+  //       promise: true,
+  //       appendPath: false,
+  //       req: function getReq(shim, fn, fnName, args) {
+  //         return args[0] && args[0].req
+  //       }
+  //     }
+  //     layer.stack = layer.stack.map(function wrapLayerMiddleware(m) {
+  //       return shim.recordMiddleware(m, spec)
+  //     })
+  //   }
+  //   const wrappedRouter = shim.recordMiddleware(middleware, {
+  //     type: shim.ROUTER,
+  //     promise: true,
+  //     appendPath: false,
+  //     req: function getReq(shim, fn, fnName, args) {
+  //       return args[0] && args[0].req
+  //     }
+  //   })
+  //   Object.keys(router).forEach(function copyKeys(k) {
+  //     wrappedRouter[k] = router[k]
+  //   })
+  //   return wrappedRouter
+  // }
 
   // Skip middleware that are already wrapped.
   if (shim.isWrapped(middleware)) {

--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -102,9 +102,6 @@ function wrapCreateContext(shim, fn, fnName, context) {
   Object.defineProperty(context.response, '_body', {
     get: () => context.__NR_body,
     set: function setBody(val) {
-      console.log('**** bodyval:', val)
-      console.error(new Error('bodyset'))
-
       if (!context.__NR_matchedSet) {
         shim.savePossibleTransactionName(context.req)
       }
@@ -118,25 +115,17 @@ function wrapCreateContext(shim, fn, fnName, context) {
   Object.defineProperty(context, '_matchedRoute', {
     get: () => context.__NR_matchedRoute,
     set: (val) => {
-      console.log('in matchedRoute')
       const match = getLayerForTransactionName(context)
 
       // match should never be undefined given _matchedRoute was set
       if (match) {
-        console.log('in match')
         const tx = shim.agent.tracer.getTransaction()
 
         if (context.__NR_matchedRoute) {
-          console.log('__NR_matchedRoute')
-          // for multiple routers, we need to ignore prevous router setting
-          // better way to do this?
           tx.nameState.popPath()
         }
 
-
         tx.nameState.appendPath(match.path)
-        console.log('match.path: ', match.path)
-
         tx.nameState.markPath()
       }
 
@@ -160,17 +149,15 @@ function wrapCreateContext(shim, fn, fnName, context) {
     return
   }
 
-  // TODO: decide if permanent remove or safe to restore
-  // Object.defineProperty(context.response, 'status', {
-  //   get: () => statusDescriptor.get.call(context.response),
-  //   set: function setStatus(val) {
-  //     if (!context.__NR_bodySet) {
-  //       console.log('*** saving possible tran name ')
-  //       shim.savePossibleTransactionName(context.req)
-  //     }
-  //     return statusDescriptor.set.call(this, val)
-  //   }
-  // })
+  Object.defineProperty(context.response, 'status', {
+    get: () => statusDescriptor.get.call(context.response),
+    set: function setStatus(val) {
+      if (!context.__NR_bodySet && !context.__NR_matchedSet) {
+        shim.savePossibleTransactionName(context.req)
+      }
+      return statusDescriptor.set.call(this, val)
+    }
+  })
 }
 
 function getLayerForTransactionName(context) {

--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -71,10 +71,15 @@ function wrapMiddleware(shim, middleware) {
     return middleware
   }
 
+  // TODO: if we instrument everything via the router, appendPath can always be true
+  // and we don't have to have any cross references here. Set to false and maybe
+  // log if there's a router. Like middleware discovered witha router property, may
+  // indicate a routing module or routing module version that is not fully supported.
   return shim.recordMiddleware(middleware, {
     type: shim.MIDDLEWARE,
     promise: true,
-    appendPath: !hasRouter,
+    appendPath: !middleware.router,
+    next: shim.LAST,
     req: function getReq(shim, fn, fnName, args) {
       return args[0] && args[0].req
     }
@@ -97,6 +102,9 @@ function wrapCreateContext(shim, fn, fnName, context) {
   Object.defineProperty(context.response, '_body', {
     get: () => context.__NR_body,
     set: function setBody(val) {
+      console.log('**** bodyval:', val)
+      console.error(new Error('bodyset'))
+
       if (!context.__NR_matchedSet) {
         shim.savePossibleTransactionName(context.req)
       }
@@ -110,12 +118,25 @@ function wrapCreateContext(shim, fn, fnName, context) {
   Object.defineProperty(context, '_matchedRoute', {
     get: () => context.__NR_matchedRoute,
     set: (val) => {
+      console.log('in matchedRoute')
       const match = getLayerForTransactionName(context)
 
       // match should never be undefined given _matchedRoute was set
       if (match) {
+        console.log('in match')
         const tx = shim.agent.tracer.getTransaction()
+
+        if (context.__NR_matchedRoute) {
+          console.log('__NR_matchedRoute')
+          // for multiple routers, we need to ignore prevous router setting
+          // better way to do this?
+          tx.nameState.popPath()
+        }
+
+
         tx.nameState.appendPath(match.path)
+        console.log('match.path: ', match.path)
+
         tx.nameState.markPath()
       }
 
@@ -139,15 +160,17 @@ function wrapCreateContext(shim, fn, fnName, context) {
     return
   }
 
-  Object.defineProperty(context.response, 'status', {
-    get: () => statusDescriptor.get.call(context.response),
-    set: function setStatus(val) {
-      if (!context.__NR_bodySet) {
-        shim.savePossibleTransactionName(context.req)
-      }
-      return statusDescriptor.set.call(this, val)
-    }
-  })
+  // TODO: decide if permanent remove or safe to restore
+  // Object.defineProperty(context.response, 'status', {
+  //   get: () => statusDescriptor.get.call(context.response),
+  //   set: function setStatus(val) {
+  //     if (!context.__NR_bodySet) {
+  //       console.log('*** saving possible tran name ')
+  //       shim.savePossibleTransactionName(context.req)
+  //     }
+  //     return statusDescriptor.set.call(this, val)
+  //   }
+  // })
 }
 
 function getLayerForTransactionName(context) {

--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -34,51 +34,25 @@ function wrapMiddleware(shim, middleware) {
     hasRouter = !!middleware.router
   }
 
-  // if (router && router.stack && router.stack.length) {
-  //   const stack = router.stack
-  //   for (let i = 0; i < stack.length; ++i) {
-  //     const layer = stack[i]
-  //     const spec = {
-  //       route: layer.path,
-  //       type: shim.MIDDLEWARE,
-  //       next: shim.LAST,
-  //       promise: true,
-  //       appendPath: false,
-  //       req: function getReq(shim, fn, fnName, args) {
-  //         return args[0] && args[0].req
-  //       }
-  //     }
-  //     layer.stack = layer.stack.map(function wrapLayerMiddleware(m) {
-  //       return shim.recordMiddleware(m, spec)
-  //     })
-  //   }
-  //   const wrappedRouter = shim.recordMiddleware(middleware, {
-  //     type: shim.ROUTER,
-  //     promise: true,
-  //     appendPath: false,
-  //     req: function getReq(shim, fn, fnName, args) {
-  //       return args[0] && args[0].req
-  //     }
-  //   })
-  //   Object.keys(router).forEach(function copyKeys(k) {
-  //     wrappedRouter[k] = router[k]
-  //   })
-  //   return wrappedRouter
-  // }
-
   // Skip middleware that are already wrapped.
   if (shim.isWrapped(middleware)) {
     return middleware
   }
 
-  // TODO: if we instrument everything via the router, appendPath can always be true
-  // and we don't have to have any cross references here. Set to false and maybe
-  // log if there's a router. Like middleware discovered witha router property, may
-  // indicate a routing module or routing module version that is not fully supported.
+  if (middleware.router) {
+    shim.logger.info(
+      [
+        'Found uninstrumented router property on Koa middleware.',
+        'This may indicate either an unsupported routing library is being used,',
+        'or a particular version of a supported library is not fully instrumented.'
+      ].join(' ')
+    )
+  }
+
   return shim.recordMiddleware(middleware, {
     type: shim.MIDDLEWARE,
     promise: true,
-    appendPath: !middleware.router,
+    appendPath: true,
     next: shim.LAST,
     req: function getReq(shim, fn, fnName, args) {
       return args[0] && args[0].req
@@ -102,7 +76,7 @@ function wrapCreateContext(shim, fn, fnName, context) {
   Object.defineProperty(context.response, '_body', {
     get: () => context.__NR_body,
     set: function setBody(val) {
-      if (!context.__NR_matchedSet) {
+      if (!context.__NR_koaRouter) {
         shim.savePossibleTransactionName(context.req)
       }
       context.__NR_body = val
@@ -111,7 +85,7 @@ function wrapCreateContext(shim, fn, fnName, context) {
   })
 
   context.__NR_matchedRoute = null
-  context.__NR_matchedSet = false
+  context.__NR_koaRouter = false
   Object.defineProperty(context, '_matchedRoute', {
     get: () => context.__NR_matchedRoute,
     set: (val) => {
@@ -132,7 +106,7 @@ function wrapCreateContext(shim, fn, fnName, context) {
       context.__NR_matchedRoute = val
       // still true if somehow match is undefined because we are
       // using koa-router naming and don't want to allow default naming
-      context.__NR_matchedSet = true
+      context.__NR_koaRouter = true
     }
   })
 
@@ -152,7 +126,7 @@ function wrapCreateContext(shim, fn, fnName, context) {
   Object.defineProperty(context.response, 'status', {
     get: () => statusDescriptor.get.call(context.response),
     set: function setStatus(val) {
-      if (!context.__NR_bodySet && !context.__NR_matchedSet) {
+      if (!context.__NR_bodySet && !context.__NR_koaRouter) {
         shim.savePossibleTransactionName(context.req)
       }
       return statusDescriptor.set.call(this, val)

--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -69,6 +69,7 @@ function wrapMiddleware(shim, middleware) {
   return shim.recordMiddleware(middleware, {
     type: shim.MIDDLEWARE,
     promise: true,
+    appendPath: false,
     req: function getReq(shim, fn, fnName, args) {
       return args[0] && args[0].req
     }

--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -1,9 +1,5 @@
 'use strict'
 
-// Toggles whether to append current path to transaction name,
-// depending on if koa-router is being used.
-let hasRouter = null
-
 module.exports = function initialize(shim, Koa) {
   if (!shim || !Koa || Object.keys(Koa.prototype).length > 1) {
     shim.logger.debug(
@@ -30,10 +26,6 @@ module.exports = function initialize(shim, Koa) {
 }
 
 function wrapMiddleware(shim, middleware) {
-  if (hasRouter === null) {
-    hasRouter = !!middleware.router
-  }
-
   // Skip middleware that are already wrapped.
   if (shim.isWrapped(middleware)) {
     return middleware

--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -1,5 +1,8 @@
 'use strict'
 
+// Toggles whether to append current path to transaction name,
+// depending on if koa-router is being used.
+let hasRouter = null
 
 module.exports = function initialize(shim, Koa) {
   if (!shim || !Koa || Object.keys(Koa.prototype).length > 1) {
@@ -28,6 +31,9 @@ module.exports = function initialize(shim, Koa) {
 
 function wrapMiddleware(shim, middleware) {
   const router = middleware.router
+  if (hasRouter === null) {
+    hasRouter = !!router
+  }
 
   if (router && router.stack && router.stack.length) {
     const stack = router.stack
@@ -69,7 +75,7 @@ function wrapMiddleware(shim, middleware) {
   return shim.recordMiddleware(middleware, {
     type: shim.MIDDLEWARE,
     promise: true,
-    appendPath: false,
+    appendPath: !hasRouter,
     req: function getReq(shim, fn, fnName, args) {
       return args[0] && args[0].req
     }

--- a/lib/router-instrumentation.js
+++ b/lib/router-instrumentation.js
@@ -8,6 +8,7 @@ module.exports = function instrumentRouter(shim, Router) {
   shim.wrapReturn(proto, 'register', wrapMiddleware)
   shim.wrapReturn(proto, 'allowedMethods', wrapAllowedMethods)
   shim.wrapReturn(proto, 'routes', wrapRoutes)
+  shim.wrapReturn(proto, 'middleware', wrapRoutes)
 
   shim.wrapMiddlewareMounter(proto, 'param', {
     route: shim.FIRST,
@@ -74,6 +75,9 @@ function wrapAllowedMethods(shim, fn, name, allowedMethodsMiddleware) {
 }
 
 function wrapRoutes(shim, fn, name, dispatchMiddleware) {
+  if (shim.isWrapped(dispatchMiddleware)) {
+    return dispatchMiddleware
+  }
   const wrappedDispatch = shim.recordMiddleware(dispatchMiddleware, {
     type: shim.ROUTER,
     promise: true,

--- a/lib/router-instrumentation.js
+++ b/lib/router-instrumentation.js
@@ -3,10 +3,18 @@
 module.exports = function instrumentRouter(shim, Router) {
   shim.setFramework(shim.KOA)
 
-  shim.wrapMiddlewareMounter(Router.prototype, 'param', {
+  const proto = Router.prototype
+
+  // app.use(router.routes())
+  // .use(router.allowedMethods());
+
+  shim.wrapReturn(proto, 'register', wrapMiddleware)
+  shim.wrap(proto, 'routes', wrapRoutes)
+
+  shim.wrapMiddlewareMounter(proto, 'param', {
     route: shim.FIRST,
-    wrapper: function wrapMiddleware(shim, middleware, fnName, route) {
-      return shim.recordParamware(middleware, {
+    wrapper: function wrapParamware(shim, paramware, fnName, route) {
+      return shim.recordParamware(paramware, {
         name: route,
         next: shim.LAST,
         promise: true,
@@ -17,4 +25,64 @@ module.exports = function instrumentRouter(shim, Router) {
       })
     }
   })
+
+  // instrument middleware from register() -> one at a time, not full stack at once
+  // instrument returned middleware from routes(), no child middleware
+
+  // koa instrumentation should be able to just bail out if already instrumented
+
+  // path, methods, middleware, opts
+  // ['blah', 'blee']
+
+  function wrapMiddleware(shim, fn, name, layer) {
+    // If Layer returned, middleware registered.
+    // If Router returned, register was called on the array of paths and we should bail.
+    if (!isLayer(layer)) {
+      return
+    }
+
+    const spec = {
+      route: layer.path,
+      type: shim.MIDDLEWARE,
+      next: shim.LAST,
+      promise: true,
+      appendPath: false,
+      req: function getReq(shim, fn, fnName, args) {
+        return args[0] && args[0].req
+      }
+    }
+
+    layer.stack = layer.stack.map(function wrapLayerMiddleware(m) {
+      // TODO: decide if we need to check to not double instrument
+      return shim.recordMiddleware(m, spec)
+    })
+  }
+}
+
+// the outer app.use() instrumentation maybe needing to know we are koa router case
+
+function wrapRoutes(shim, fn) {
+  return function wrappedRoutes() {
+    const middleware = fn.apply(this, arguments)
+    const router = middleware.router
+
+    const wrappedRouter = shim.recordMiddleware(middleware, {
+      type: shim.ROUTER,
+      promise: true,
+      appendPath: false,
+      req: function getReq(shim, fn, fnName, args) {
+        return args[0] && args[0].req
+      }
+    })
+
+    Object.keys(router).forEach(function copyKeys(k) {
+      wrappedRouter[k] = router[k]
+    })
+
+    return middleware
+  }
+}
+
+function isLayer(obj) {
+  return !!(obj.paramNames && obj.path)
 }

--- a/lib/router-instrumentation.js
+++ b/lib/router-instrumentation.js
@@ -5,9 +5,6 @@ module.exports = function instrumentRouter(shim, Router) {
 
   const proto = Router.prototype
 
-  // app.use(router.routes())
-  // .use(router.allowedMethods());
-
   shim.wrapReturn(proto, 'register', wrapMiddleware)
   shim.wrapReturn(proto, 'allowedMethods', wrapAllowedMethods)
   shim.wrap(proto, 'routes', wrapRoutes)
@@ -27,22 +24,7 @@ module.exports = function instrumentRouter(shim, Router) {
     }
   })
 
-  // instrument middleware from register() -> one at a time, not full stack at once
-  // instrument returned middleware from routes(), no child middleware
-
-  // koa instrumentation should be able to just bail out if already instrumented
-
-  // path, methods, middleware, opts
-  // ['blah', 'blee']
-
-
-  // TODO: eventually, ctx.matched has layers taht havea the path fully merged
-  // figure out where/how as instrumenting individually screws up
-  // the segment naming for nested routers
-
   function wrapMiddleware(shim, fn, name, layer) {
-    // If Layer returned, middleware registered.
-    // If Router returned, register was called on the array of paths and we should bail.
     if (!isLayer(layer)) {
       return
     }
@@ -65,7 +47,6 @@ module.exports = function instrumentRouter(shim, Router) {
       if (shim.isWrapped(m)) {
         return m
       }
-
 
       return shim.recordMiddleware(m, spec)
     })

--- a/lib/router-instrumentation.js
+++ b/lib/router-instrumentation.js
@@ -42,9 +42,8 @@ module.exports = function instrumentRouter(shim, Router) {
     }
 
     layer.stack = layer.stack.map(function wrapLayerMiddleware(m) {
-      // TODO: if we auto instrument the terminal middleware, maybe this
-      // code path is no longer necessary as all the middleware will be
-      // instrumented by this point
+      // allowedMethods middleware can exist in a stack so we need to
+      // protect against re-instrumenting.
       if (shim.isWrapped(m)) {
         return m
       }
@@ -55,14 +54,9 @@ module.exports = function instrumentRouter(shim, Router) {
 }
 
 function wrapAllowedMethods(shim, fn, name, allowedMethodsMiddleware) {
-  function setRouteHandledOnContextWrapper() {
-    const [ctx] = shim.argsToArray.apply(shim, arguments)
-    ctx.__NR_koaRouter = true
+  const wrapped = shim.wrap(allowedMethodsMiddleware, wrapAllowedMethodsMiddleware)
 
-    return allowedMethodsMiddleware.apply(this, arguments)
-  }
-
-  return shim.recordMiddleware(setRouteHandledOnContextWrapper, {
+  return shim.recordMiddleware(wrapped, {
     name: allowedMethodsMiddleware.name,
     type: shim.MIDDLEWARE,
     promise: true,
@@ -72,6 +66,15 @@ function wrapAllowedMethods(shim, fn, name, allowedMethodsMiddleware) {
       return args[0] && args[0].req
     }
   })
+}
+
+function wrapAllowedMethodsMiddleware(shim, original) {
+  return function setRouteHandledOnContextWrapper() {
+    const [ctx] = shim.argsToArray.apply(shim, arguments)
+    ctx.__NR_koaRouter = true
+
+    return original.apply(this, arguments)
+  }
 }
 
 function wrapRoutes(shim, fn, name, dispatchMiddleware) {

--- a/lib/router-instrumentation.js
+++ b/lib/router-instrumentation.js
@@ -48,7 +48,7 @@ module.exports = function instrumentRouter(shim, Router) {
     }
 
     const spec = {
-      route: layer.path,
+      route: () => layer.path, // defer retrieval
       type: shim.MIDDLEWARE,
       next: shim.LAST,
       promise: true,
@@ -91,13 +91,10 @@ function wrapAllowedMethods(shim, fn, name, allowedMethodsMiddleware) {
   })
 }
 
-// the outer app.use() instrumentation maybe needing to know we are koa router case
-
 // TODO: this can prob be simplified ot wrappedreturn
 function wrapRoutes(shim, fn) {
   return function wrappedRoutes() {
     const dispatchMiddleware = fn.apply(this, arguments)
-    //const router = middleware.router
 
     const wrappedDispatch = shim.recordMiddleware(dispatchMiddleware, {
       type: shim.ROUTER,
@@ -109,9 +106,6 @@ function wrapRoutes(shim, fn) {
       }
     })
 
-    // Is this safe if any keys overlap?
-    // Noticed the "length" property mismatches between original and wrapped
-    // Any other differences?
     Object.keys(dispatchMiddleware).forEach(function copyKeys(k) {
       wrappedDispatch[k] = dispatchMiddleware[k]
     })

--- a/lib/router-instrumentation.js
+++ b/lib/router-instrumentation.js
@@ -7,7 +7,7 @@ module.exports = function instrumentRouter(shim, Router) {
 
   shim.wrapReturn(proto, 'register', wrapMiddleware)
   shim.wrapReturn(proto, 'allowedMethods', wrapAllowedMethods)
-  shim.wrap(proto, 'routes', wrapRoutes)
+  shim.wrapReturn(proto, 'routes', wrapRoutes)
 
   shim.wrapMiddlewareMounter(proto, 'param', {
     route: shim.FIRST,
@@ -56,12 +56,13 @@ module.exports = function instrumentRouter(shim, Router) {
 function wrapAllowedMethods(shim, fn, name, allowedMethodsMiddleware) {
   function setRouteHandledOnContextWrapper() {
     const [ctx] = shim.argsToArray.apply(shim, arguments)
-    ctx.__NR_matchedSet = true // TODO: rename this to be more of a "handled by router"
+    ctx.__NR_koaRouter = true
 
     return allowedMethodsMiddleware.apply(this, arguments)
   }
 
   return shim.recordMiddleware(setRouteHandledOnContextWrapper, {
+    name: allowedMethodsMiddleware.name,
     type: shim.MIDDLEWARE,
     promise: true,
     appendPath: false,
@@ -72,27 +73,19 @@ function wrapAllowedMethods(shim, fn, name, allowedMethodsMiddleware) {
   })
 }
 
-// TODO: this can prob be simplified ot wrappedreturn
-function wrapRoutes(shim, fn) {
-  return function wrappedRoutes() {
-    const dispatchMiddleware = fn.apply(this, arguments)
+function wrapRoutes(shim, fn, name, dispatchMiddleware) {
+  const wrappedDispatch = shim.recordMiddleware(dispatchMiddleware, {
+    type: shim.ROUTER,
+    promise: true,
+    appendPath: false,
+    next: shim.LAST,
+    req: function getReq(shim, fn, fnName, args) {
+      return args[0] && args[0].req
+    }
+  })
 
-    const wrappedDispatch = shim.recordMiddleware(dispatchMiddleware, {
-      type: shim.ROUTER,
-      promise: true,
-      appendPath: false,
-      next: shim.LAST,
-      req: function getReq(shim, fn, fnName, args) {
-        return args[0] && args[0].req
-      }
-    })
-
-    Object.keys(dispatchMiddleware).forEach(function copyKeys(k) {
-      wrappedDispatch[k] = dispatchMiddleware[k]
-    })
-
-    return wrappedDispatch
-  }
+  // copy keys from dispatchMiddleware to wrapped version
+  return Object.assign(wrappedDispatch, dispatchMiddleware)
 }
 
 function isLayer(obj) {

--- a/lib/router-instrumentation.js
+++ b/lib/router-instrumentation.js
@@ -9,6 +9,7 @@ module.exports = function instrumentRouter(shim, Router) {
   // .use(router.allowedMethods());
 
   shim.wrapReturn(proto, 'register', wrapMiddleware)
+  shim.wrapReturn(proto, 'allowedMethods', wrapAllowedMethods)
   shim.wrap(proto, 'routes', wrapRoutes)
 
   shim.wrapMiddlewareMounter(proto, 'param', {
@@ -34,6 +35,11 @@ module.exports = function instrumentRouter(shim, Router) {
   // path, methods, middleware, opts
   // ['blah', 'blee']
 
+
+  // TODO: eventually, ctx.matched has layers taht havea the path fully merged
+  // figure out where/how as instrumenting individually screws up
+  // the segment naming for nested routers
+
   function wrapMiddleware(shim, fn, name, layer) {
     // If Layer returned, middleware registered.
     // If Router returned, register was called on the array of paths and we should bail.
@@ -53,33 +59,64 @@ module.exports = function instrumentRouter(shim, Router) {
     }
 
     layer.stack = layer.stack.map(function wrapLayerMiddleware(m) {
-      // TODO: decide if we need to check to not double instrument
+      // TODO: if we auto instrument the terminal middleware, maybe this
+      // code path is no longer necessary as all the middleware will be
+      // instrumented by this point
+      if (shim.isWrapped(m)) {
+        return m
+      }
+
+
       return shim.recordMiddleware(m, spec)
     })
   }
 }
 
+function wrapAllowedMethods(shim, fn, name, allowedMethodsMiddleware) {
+  function setRouteHandledOnContextWrapper() {
+    const [ctx] = shim.argsToArray.apply(shim, arguments)
+    ctx.__NR_matchedSet = true // TODO: rename this to be more of a "handled by router"
+
+    return allowedMethodsMiddleware.apply(this, arguments)
+  }
+
+  return shim.recordMiddleware(setRouteHandledOnContextWrapper, {
+    type: shim.MIDDLEWARE,
+    promise: true,
+    appendPath: false,
+    next: shim.LAST,
+    req: function getReq(shim, fn, fnName, args) {
+      return args[0] && args[0].req
+    }
+  })
+}
+
 // the outer app.use() instrumentation maybe needing to know we are koa router case
 
+// TODO: this can prob be simplified ot wrappedreturn
 function wrapRoutes(shim, fn) {
   return function wrappedRoutes() {
-    const middleware = fn.apply(this, arguments)
-    const router = middleware.router
+    const dispatchMiddleware = fn.apply(this, arguments)
+    //const router = middleware.router
 
-    const wrappedRouter = shim.recordMiddleware(middleware, {
+    const wrappedDispatch = shim.recordMiddleware(dispatchMiddleware, {
       type: shim.ROUTER,
       promise: true,
       appendPath: false,
+      next: shim.LAST,
       req: function getReq(shim, fn, fnName, args) {
         return args[0] && args[0].req
       }
     })
 
-    Object.keys(router).forEach(function copyKeys(k) {
-      wrappedRouter[k] = router[k]
+    // Is this safe if any keys overlap?
+    // Noticed the "length" property mismatches between original and wrapped
+    // Any other differences?
+    Object.keys(dispatchMiddleware).forEach(function copyKeys(k) {
+      wrappedDispatch[k] = dispatchMiddleware[k]
     })
 
-    return middleware
+    return wrappedDispatch
   }
 }
 

--- a/nr-hooks.js
+++ b/nr-hooks.js
@@ -3,7 +3,7 @@
 module.exports = [{
   type: 'web-framework',
   moduleName: 'koa',
-  onRequire: require('./lib/instrumentation') // TODO: update file name
+  onRequire: require('./lib/instrumentation')
 }, {
   type: 'web-framework',
   moduleName: 'koa-router',

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   },
   "author": "New Relic Node.js agent team <nodejs@newrelic.com>",
   "license": "SEE LICENSE IN LICENSE",
+  "engines": {
+    "node": ">=6.0.0 <11.0.0"
+  },
   "devDependencies": {
     "@newrelic/test-utilities": "^3.0.0",
     "coveralls": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "koa": "^2.6.1",
     "koa-route": "^3.2.0",
     "koa-router": "^7.4.0",
-    "newrelic": "^5.8.0",
+    "newrelic": "^5.9.0",
     "semver": "^5.6.0",
     "tap": "^12.0.1"
   },
@@ -33,6 +33,6 @@
     "methods": "^1.1.2"
   },
   "peerDependencies": {
-    "newrelic": ">=5.8.0"
+    "newrelic": ">=5.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "koa": "^2.6.1",
     "koa-route": "^3.2.0",
     "koa-router": "^7.4.0",
-    "newrelic": "^5.7.0",
+    "newrelic": "^5.8.0",
     "semver": "^5.6.0",
     "tap": "^12.0.1"
   },
@@ -30,6 +30,6 @@
     "methods": "^1.1.2"
   },
   "peerDependencies": {
-    "newrelic": ">=5.7.0"
+    "newrelic": ">=5.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint *.js lib tests"
   },
   "author": "New Relic Node.js agent team <nodejs@newrelic.com>",
-  "license": "LicenseRef-LICENSE",
+  "license": "SEE LICENSE IN LICENSE",
   "devDependencies": {
     "@newrelic/test-utilities": "^3.0.0",
     "coveralls": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "methods": "^1.1.2"
   },
   "peerDependencies": {
-    "newrelic": ">=3.3.1"
+    "newrelic": ">=5.7.0"
   }
 }

--- a/tests/unit/router.tap.js
+++ b/tests/unit/router.tap.js
@@ -6,16 +6,16 @@ var methods = require('methods')
 var instrumentation = require('../../lib/router-instrumentation.js')
 
 var WRAPPED_METHODS = [
-  'param'
+  'param',
+  'register',
+  'routes',
+  'middleware',
+  'allowedMethods'
 ]
 
 var UNWRAPPED_METHODS = methods.concat([
-  'register',
   'use',
   'prefix',
-  'routes',
-  'middleware',
-  'allowedMethods',
   'all',
   'redirect',
   'route',

--- a/tests/versioned/koa-route.tap.js
+++ b/tests/versioned/koa-route.tap.js
@@ -50,8 +50,7 @@ tap.test('koa-route instrumentation', function(t) {
           children: [{
             name: 'Nodejs/Middleware/Koa/firstMiddleware//resource'
           }]
-        }],
-        'should have expected segments'
+        }]
       )
       t.equal(
         tx.name,
@@ -85,8 +84,7 @@ tap.test('koa-route instrumentation', function(t) {
               }
             ]
           }]
-        }],
-        'should have expected segments'
+        }]
       )
       t.equal(
         tx.name,
@@ -121,8 +119,7 @@ tap.test('koa-route instrumentation', function(t) {
               }
             ]
           }]
-        }],
-        'should have expected segments'
+        }]
       )
       t.equal(
         tx.name,
@@ -151,8 +148,7 @@ tap.test('koa-route instrumentation', function(t) {
           children: [{
             name: 'Nodejs/Middleware/Koa/firstMiddleware//:first'
           }]
-        }],
-        'should have expected segments'
+        }]
       )
       t.equal(
         tx.name,
@@ -187,8 +183,7 @@ tap.test('koa-route instrumentation', function(t) {
                 }
               ]
             }]
-          }],
-          'should have expected segments'
+          }]
         )
         t.equal(
           tx.name,
@@ -231,8 +226,7 @@ tap.test('koa-route instrumentation', function(t) {
               }
             ]
           }]
-        }],
-        'should have expected segments'
+        }]
       )
       t.equal(
         tx.name,

--- a/tests/versioned/koa-router.tap.js
+++ b/tests/versioned/koa-router.tap.js
@@ -84,6 +84,33 @@ tap.test('koa-router instrumentation', (t) => {
       run()
     })
 
+    t.test('should name after matched path using middleware() alias', (t) => {
+      router.get('/:first', function firstMiddleware(ctx) {
+        ctx.body = 'first'
+      })
+      app.use(router.middleware())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
+            children: [{
+              name: 'Koa/Router: /',
+              children: [{
+                name: 'Nodejs/Middleware/Koa/firstMiddleware//:first'
+              }]
+            }]
+          }]
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:first',
+          'transaction should be named after the matched path'
+        )
+        t.end()
+      })
+      run()
+    })
+
     t.test('should name and produce segments for matched regex path', (t) => {
       router.get(/.*rst$/, function firstMiddleware(ctx) {
         ctx.body = 'first'

--- a/tests/versioned/koa-router.tap.js
+++ b/tests/versioned/koa-router.tap.js
@@ -111,7 +111,7 @@ tap.test('koa-router instrumentation', (t) => {
       run('/first')
     })
 
-    t.test('should name and produce segments for matched regex path', (t) => {
+    t.test('should name and produce segments for matched wildcard path', (t) => {
       router.get('/:first/(.*)', function firstMiddleware(ctx) {
         ctx.body = 'first'
       })
@@ -515,6 +515,7 @@ tap.test('koa-router instrumentation', (t) => {
 
   // TODO: appears segment pathing negativelh impacted by recent changes
   // perhaps the removal of accidental appending
+  // router.setPrefix() modifies the path of nested layers.
   t.test('using nested or prefixed routers', (t) => {
     t.beforeEach((done) => testSetup(done))
     t.afterEach((done) => tearDown(done))

--- a/tests/versioned/koa-router.tap.js
+++ b/tests/versioned/koa-router.tap.js
@@ -58,9 +58,18 @@ tap.test('koa-router instrumentation', (t) => {
     t.autoend()
 
     t.test('should name and produce segments for matched path', (t) => {
-      router.get('/:first', function firstMiddleware(ctx) {
-        ctx.body = 'first'
-      })
+      router.get(
+        '/:first',
+        function firstMiddleware(ctx, next) {
+          next().then(() => {
+            ctx.body = 'first'
+          })
+        },
+        function secondMiddleware(ctx) {
+          ctx.body = 'second'
+        }
+      )
+
       app.use(router.routes())
       helper.agent.on('transactionFinished', (tx) => {
         t.exactSegments(
@@ -69,7 +78,10 @@ tap.test('koa-router instrumentation', (t) => {
             children: [{
               name: 'Koa/Router: /',
               children: [{
-                name: 'Nodejs/Middleware/Koa/firstMiddleware//:first'
+                name: 'Nodejs/Middleware/Koa/firstMiddleware//:first',
+                children: [{
+                  name: 'Nodejs/Middleware/Koa/secondMiddleware//:first'
+                }]
               }]
             }]
           }]
@@ -668,151 +680,21 @@ tap.test('koa-router instrumentation', (t) => {
   })
 
   t.test('using allowedMethods', (t) => {
-    t.beforeEach((done) => testSetup(done))
-    t.afterEach((done) => tearDown(done))
     t.autoend()
 
-    t.test('should name transaction after `method now allowed` message', (t) => {
-      router.post('/:first', function firstMiddleware() {})
-      app.use(router.routes())
-      app.use(router.allowedMethods({throw: true}))
-      helper.agent.on('transactionFinished', (tx) => {
-        t.exactSegments(
-          tx.trace.root, [{
-            name: 'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
-            children: [{
-              name: 'Koa/Router: /',
-              children: [{
-                name: 'Nodejs/Middleware/Koa/allowedMethods'
-              }]
-            }]
-          }]
-        )
-        t.equal(
-          tx.name,
-          'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
-          'transaction should be named after corresponding status code message'
-        )
-        const errors = helper.agent.errors.errors
-        t.equal(errors.length, 1, 'the error has been recorded')
-        t.end()
-      })
-      run()
-    })
+    t.test('with throw: true', (t) => {
+      t.beforeEach((done) => testSetup(done))
+      t.afterEach((done) => tearDown(done))
+      t.autoend()
 
-    t.test('should name transaction after `not implemented` message', (t) => {
-      router = new Router({ methods: ['POST'] })
-      router.post('/:first', function firstMiddleware() {})
-      app.use(router.routes())
-      app.use(router.allowedMethods())
-      helper.agent.on('transactionFinished', (tx) => {
-        t.exactSegments(
-          tx.trace.root, [{
-            name: 'WebTransaction/WebFrameworkUri/Koa/GET/(not implemented)',
-            children: [{
-              name: 'Koa/Router: /',
-              children: [{
-                name: 'Nodejs/Middleware/Koa/allowedMethods'
-              }]
-            }]
-          }]
-        )
-        t.equal(
-          tx.name,
-          'WebTransaction/WebFrameworkUri/Koa/GET/(not implemented)',
-          'transaction should be named after corresponding status code message'
-        )
-        // TODO: this seems wrong because of no {throw: true}
-        const errors = helper.agent.errors.errors
-        t.equal(errors.length, 1, 'the error has been recorded')
-        t.end()
-      })
-      run()
-    })
-
-    t.test('should name and produce segments for existing matched path', (t) => {
-      router = new Router({ methods: ['GET'] })
-      router.get('/:first', function firstMiddleware(ctx) {
-        ctx.body = 'first'
-      })
-      app.use(router.routes())
-      app.use(router.allowedMethods())
-      helper.agent.on('transactionFinished', (tx) => {
-        t.exactSegments(
-          tx.trace.root, [{
-            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
-            children: [{
-              name: 'Koa/Router: /',
-              children: [{
-                name: 'Nodejs/Middleware/Koa/firstMiddleware//:first'
-              }]
-            }]
-          }]
-        )
-        t.equal(
-          tx.name,
-          'WebTransaction/WebFrameworkUri/Koa/GET//:first',
-          'transaction should be named after the matched path'
-        )
-        t.end()
-      })
-      run()
-    })
-
-    t.test('should name tx from status code message', (t) => {
-      // This will register the same middleware (i.e. secondMiddleware)
-      // under both the /:first and /:second routes. Use does not register middleware
-      // w/ supported methods they cannot handle routes.
-      router.use(['/:first', '/:second'], function secondMiddleware(ctx, next) {
-        ctx.body += ' second'
-        return next()
-      })
-      router.post('/:second', function terminalMiddleware(ctx) {
-        ctx.body = ' second'
-      })
-      app.use(router.routes())
-      app.use(router.allowedMethods({throw: true}))
-      helper.agent.on('transactionFinished', (tx) => {
-        t.exactSegments(
-          tx.trace.root, [{
-            name: 'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
-            children: [{
-              name: 'Koa/Router: /',
-              children: [{
-                name: 'Nodejs/Middleware/Koa/allowedMethods'
-              }]
-            }]
-          }]
-        )
-        t.equal(
-          tx.name,
-          'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
-          'transaction should be named after the last matched path'
-        )
-        t.end()
-      })
-      run()
-    })
-
-    t.test('should name tx after `method not allowed` with prefixed router', (t) => {
-      app.use(function appLevelMiddleware(ctx, next) {
-        return next().then(() => {
-          ctx.body = 'should not set the name'
-        })
-      })
-      router.post('/second', function secondMiddleware(ctx) {
-        ctx.body = 'should not set the name'
-      })
-      router.prefix('/:first')
-      app.use(router.routes())
-      app.use(router.allowedMethods())
-
-      helper.agent.on('transactionFinished', (tx) => {
-        t.exactSegments(
-          tx.trace.root, [{
-            name: 'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
-            children: [{
-              name: 'Nodejs/Middleware/Koa/appLevelMiddleware',
+      t.test('should name transaction after status `method now allowed` message', (t) => {
+        router.post('/:first', function firstMiddleware() {})
+        app.use(router.routes())
+        app.use(router.allowedMethods({throw: true}))
+        helper.agent.on('transactionFinished', (tx) => {
+          t.exactSegments(
+            tx.trace.root, [{
+              name: 'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
               children: [{
                 name: 'Koa/Router: /',
                 children: [{
@@ -820,41 +702,28 @@ tap.test('koa-router instrumentation', (t) => {
                 }]
               }]
             }]
-          }]
-        )
-        t.equal(
-          tx.name,
-          'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
-          'should be named after the last matched path'
-        )
-        t.end()
-      })
-      run('/123/second')
-    })
-
-    t.test('error handler normalizes tx name if body is reset without status', (t) => {
-      app.use(function errorHandler(ctx, next) {
-        return next().catch(() => {
-          // resetting the body without manually persisting ctx.status
-          // results in status 200
-          ctx.body = { msg: 'error is handled' }
+          )
+          t.equal(
+            tx.name,
+            'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
+            'transaction should be named after corresponding status code message'
+          )
+          const errors = helper.agent.errors.errors
+          t.equal(errors.length, 1, 'the error has been recorded')
+          t.end()
         })
+        run()
       })
 
-      const nestedRouter = new Router()
-      nestedRouter.post('/:second', function terminalMiddleware(ctx) {
-        ctx.body = 'would want this to set name if verb were correct'
-      })
-      router.use('/:first', nestedRouter.routes(), nestedRouter.allowedMethods())
-      app.use(router.routes())
-      app.use(router.allowedMethods({throw: true}))
-
-      helper.agent.on('transactionFinished', (tx) => {
-        t.exactSegments(
-          tx.trace.root, [{
-            name: 'WebTransaction/NormalizedUri/*',
-            children: [{
-              name: 'Nodejs/Middleware/Koa/errorHandler',
+      t.test('should name transaction after status `not implemented` message', (t) => {
+        router = new Router({ methods: ['POST'] })
+        router.post('/:first', function firstMiddleware() {})
+        app.use(router.routes())
+        app.use(router.allowedMethods({throw: true}))
+        helper.agent.on('transactionFinished', (tx) => {
+          t.exactSegments(
+            tx.trace.root, [{
+              name: 'WebTransaction/WebFrameworkUri/Koa/GET/(not implemented)',
               children: [{
                 name: 'Koa/Router: /',
                 children: [{
@@ -862,28 +731,27 @@ tap.test('koa-router instrumentation', (t) => {
                 }]
               }]
             }]
-          }]
-        )
-        t.equal(
-          tx.name,
-          'WebTransaction/NormalizedUri/*',
-          'should have normalized transaction name'
-        )
-        const errors = helper.agent.errors.errors
-        t.equal(errors.length, 0, 'error should not be recorded')
-        t.end()
-      })
-      run('/123/456')
-    })
+          )
+          t.equal(
+            tx.name,
+            'WebTransaction/WebFrameworkUri/Koa/GET/(not implemented)',
+            'transaction should be named after corresponding status code message'
+          )
 
-    t.test(
-      'should name tx after status message when base middleware does not set body',
-      (t) => {
-        // Because allowedMethods throws & no user catching, it is considered
-        // unhandled and will push the base route back on
-        app.use(function baseMiddleware(ctx, next) {
-          return next()
-          // does not set ctx.body or ctx.status
+          const errors = helper.agent.errors.errors
+          t.equal(errors.length, 1, 'the error has been recorded')
+          t.end()
+        })
+        run()
+      })
+
+      t.test('error handler normalizes tx name if body is reset without status', (t) => {
+        app.use(function errorHandler(ctx, next) {
+          return next().catch(() => {
+            // resetting the body without manually persisting ctx.status
+            // results in status 200
+            ctx.body = { msg: 'error is handled' }
+          })
         })
 
         const nestedRouter = new Router()
@@ -897,9 +765,161 @@ tap.test('koa-router instrumentation', (t) => {
         helper.agent.on('transactionFinished', (tx) => {
           t.exactSegments(
             tx.trace.root, [{
+              name: 'WebTransaction/NormalizedUri/*',
+              children: [{
+                name: 'Nodejs/Middleware/Koa/errorHandler',
+                children: [{
+                  name: 'Koa/Router: /',
+                  children: [{
+                    name: 'Nodejs/Middleware/Koa/allowedMethods'
+                  }]
+                }]
+              }]
+            }]
+          )
+          t.equal(
+            tx.name,
+            'WebTransaction/NormalizedUri/*',
+            'should have normalized transaction name'
+          )
+          const errors = helper.agent.errors.errors
+          t.equal(errors.length, 0, 'error should not be recorded')
+          t.end()
+        })
+        run('/123/456')
+      })
+
+      t.test(
+        'should name tx after status message when base middleware does not set body',
+        (t) => {
+          // Because allowedMethods throws & no user catching, it is considered
+          // unhandled and will push the base route back on
+          app.use(function baseMiddleware(ctx, next) {
+            return next()
+            // does not set ctx.body or ctx.status
+          })
+
+          const nestedRouter = new Router()
+          nestedRouter.post('/:second', function terminalMiddleware(ctx) {
+            ctx.body = 'would want this to set name if verb were correct'
+          })
+          router.use('/:first', nestedRouter.routes(), nestedRouter.allowedMethods())
+          app.use(router.routes())
+          app.use(router.allowedMethods({throw: true}))
+
+          helper.agent.on('transactionFinished', (tx) => {
+            t.exactSegments(
+              tx.trace.root, [{
+                name: 'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
+                children: [{
+                  name: 'Nodejs/Middleware/Koa/baseMiddleware',
+                  children: [{
+                    name: 'Koa/Router: /',
+                    children: [{
+                      name: 'Nodejs/Middleware/Koa/allowedMethods'
+                    }]
+                  }]
+                }]
+              }]
+            )
+            t.equal(
+              tx.name,
+              'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
+              'should name after returned status code'
+            )
+            const errors = helper.agent.errors.errors
+            t.equal(errors.length, 1, 'should notice thrown error')
+
+            t.end()
+          })
+          run('/123/456')
+        }
+      )
+    })
+
+    t.test('with throw: false', (t) => {
+      t.beforeEach((done) => testSetup(done))
+      t.afterEach((done) => tearDown(done))
+      t.autoend()
+
+      t.test('should name transaction after status `method now allowed` message', (t) => {
+        router.post('/:first', function firstMiddleware() {})
+        app.use(router.routes())
+        app.use(router.allowedMethods())
+        helper.agent.on('transactionFinished', (tx) => {
+          t.exactSegments(
+            tx.trace.root, [{
               name: 'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
               children: [{
-                name: 'Nodejs/Middleware/Koa/baseMiddleware',
+                name: 'Koa/Router: /',
+                children: [{
+                  name: 'Nodejs/Middleware/Koa/allowedMethods'
+                }]
+              }]
+            }]
+          )
+          t.equal(
+            tx.name,
+            'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
+            'transaction should be named after corresponding status code message'
+          )
+          // Agent will automatically create error for 405 status code.
+          const errors = helper.agent.errors.errors
+          t.equal(errors.length, 1, 'the error has been recorded')
+          t.end()
+        })
+        run()
+      })
+
+      t.test('should name transaction after status `not implemented` message', (t) => {
+        router = new Router({ methods: ['POST'] })
+        router.post('/:first', function firstMiddleware() {})
+        app.use(router.routes())
+        app.use(router.allowedMethods())
+        helper.agent.on('transactionFinished', (tx) => {
+          t.exactSegments(
+            tx.trace.root, [{
+              name: 'WebTransaction/WebFrameworkUri/Koa/GET/(not implemented)',
+              children: [{
+                name: 'Koa/Router: /',
+                children: [{
+                  name: 'Nodejs/Middleware/Koa/allowedMethods'
+                }]
+              }]
+            }]
+          )
+          t.equal(
+            tx.name,
+            'WebTransaction/WebFrameworkUri/Koa/GET/(not implemented)',
+            'transaction should be named after corresponding status code message'
+          )
+          // Agent will automatically create error for 501 status code.
+          const errors = helper.agent.errors.errors
+          t.equal(errors.length, 1, 'the error has been recorded')
+          t.end()
+        })
+        run()
+      })
+
+      t.test('should name tx after `method not allowed` with prefixed router', (t) => {
+        app.use(function appLevelMiddleware(ctx, next) {
+          return next().then(() => {
+            ctx.body = 'should not set the name'
+          })
+        })
+        router.post('/second', function secondMiddleware(ctx) {
+          ctx.body = 'should not set the name'
+        })
+        router.prefix('/:first')
+        app.use(router.routes())
+        app.use(router.allowedMethods())
+
+        helper.agent.on('transactionFinished', (tx) => {
+          t.exactSegments(
+            tx.trace.root, [{
+              name: 'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
+              children: [{
+                name: 'Nodejs/Middleware/Koa/appLevelMiddleware',
                 children: [{
                   name: 'Koa/Router: /',
                   children: [{
@@ -912,16 +932,82 @@ tap.test('koa-router instrumentation', (t) => {
           t.equal(
             tx.name,
             'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
-            'should name after returned status code'
+            'transaction should be named after corresponding status code message'
           )
-          const errors = helper.agent.errors.errors
-          t.equal(errors.length, 1, 'should notice thrown error')
-
           t.end()
         })
-        run('/123/456')
-      }
-    )
+        run('/123/second')
+      })
+
+      t.test('should name tx after `not implemented` with prefixed router', (t) => {
+        router = new Router({ methods: ['POST'] })
+
+        app.use(function appLevelMiddleware(ctx, next) {
+          return next().then(() => {
+            ctx.body = 'should not set the name'
+          })
+        })
+        router.post('/second', function secondMiddleware(ctx) {
+          ctx.body = 'should not set the name'
+        })
+        router.prefix('/:first')
+        app.use(router.routes())
+        app.use(router.allowedMethods())
+
+        helper.agent.on('transactionFinished', (tx) => {
+          t.exactSegments(
+            tx.trace.root, [{
+              name: 'WebTransaction/WebFrameworkUri/Koa/GET/(not implemented)',
+              children: [{
+                name: 'Nodejs/Middleware/Koa/appLevelMiddleware',
+                children: [{
+                  name: 'Koa/Router: /',
+                  children: [{
+                    name: 'Nodejs/Middleware/Koa/allowedMethods'
+                  }]
+                }]
+              }]
+            }]
+          )
+          t.equal(
+            tx.name,
+            'WebTransaction/WebFrameworkUri/Koa/GET/(not implemented)',
+            'transaction should be named after corresponding status code message'
+          )
+          t.end()
+        })
+        run('/123/first')
+      })
+
+      t.test('should name and produce segments for existing matched path', (t) => {
+        router = new Router({ methods: ['GET'] })
+        router.get('/:first', function firstMiddleware(ctx) {
+          ctx.body = 'first'
+        })
+        app.use(router.routes())
+        app.use(router.allowedMethods())
+        helper.agent.on('transactionFinished', (tx) => {
+          t.exactSegments(
+            tx.trace.root, [{
+              name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
+              children: [{
+                name: 'Koa/Router: /',
+                children: [{
+                  name: 'Nodejs/Middleware/Koa/firstMiddleware//:first'
+                }]
+              }]
+            }]
+          )
+          t.equal(
+            tx.name,
+            'WebTransaction/WebFrameworkUri/Koa/GET//:first',
+            'transaction should be named after the matched path'
+          )
+          t.end()
+        })
+        run()
+      })
+    })
   })
 
   t.autoend()

--- a/tests/versioned/koa-router.tap.js
+++ b/tests/versioned/koa-router.tap.js
@@ -20,7 +20,7 @@ tap.test('koa-router instrumentation', (t) => {
     paramMiddlewareName = 'Nodejs/Middleware/Koa/<anonymous>//:first'
   }
 
-  t.beforeEach((done) => {
+  function testSetup(done) {
     helper = utils.TestAgent.makeInstrumented()
     helper.registerInstrumentation({
       moduleName: 'koa',
@@ -37,564 +37,729 @@ tap.test('koa-router instrumentation', (t) => {
     Router = require('koa-router')
     router = new Router()
     done()
-  })
+  }
 
-  t.afterEach((done) => {
+  function tearDown(done) {
     server.close()
     app = null
     router = null
     Router = null
     helper && helper.unload()
     done()
-  })
+  }
 
-  t.test('should name and produce segments for matched path', (t) => {
-    router.get('/:first', function firstMiddleware(ctx) {
-      ctx.body = 'first'
-    })
-    app.use(router.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
-          children: [{
-            name: 'Koa/Router: /',
-            children: [{
-              name: 'Nodejs/Middleware/Koa/firstMiddleware//:first'
-            }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:first',
-        'transaction should be named after the matched path'
-      )
-      t.end()
-    })
-    run()
-  })
+  t.test('with single router', (t) => {
+    t.beforeEach((done) => testSetup(done))
+    t.afterEach((done) => tearDown(done))
+    t.autoend()
 
-  t.test('should name and produce segments for matched regex path', (t) => {
-    router.get(/.*rst$/, function firstMiddleware(ctx) {
-      ctx.body = 'first'
-    })
-    app.use(router.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//.*rst$',
-          children: [{
-            name: 'Koa/Router: /',
+    t.test('should name and produce segments for matched path', (t) => {
+      router.get('/:first', function firstMiddleware(ctx) {
+        ctx.body = 'first'
+      })
+      app.use(router.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
             children: [{
-              name: 'Nodejs/Middleware/Koa/firstMiddleware//.*rst$/'
-            }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//.*rst$',
-        'transaction should be named after the matched regex pattern'
-      )
-      t.end()
-    })
-    run('/first')
-  })
-
-  t.test('should name and produce segments for matched regex path', (t) => {
-    router.get('/:first/(.*)', function firstMiddleware(ctx) {
-      ctx.body = 'first'
-    })
-    app.use(router.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first/(.*)',
-          children: [{
-            name: 'Koa/Router: /',
-            children: [{
-              name: 'Nodejs/Middleware/Koa/firstMiddleware//:first/(.*)'
-            }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:first/(.*)',
-        'transaction should be named after the matched regex path'
-      )
-      t.end()
-    })
-    run('/123/456')
-  })
-
-  t.test('should name and produce segments with router paramware', (t) => {
-    router.param('first', function firstParamware(id, ctx, next) {
-      ctx.body = 'first'
-      return next()
-    })
-    router.get('/:first', function firstMiddleware(ctx, next) {
-      return next()
-    })
-    app.use(router.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
-          children: [{
-            name: 'Koa/Router: /',
-            children: [{
-              name: paramMiddlewareName,
+              name: 'Koa/Router: /',
               children: [{
-                name: 'Nodejs/Middleware/Koa/firstParamware//[param handler :first]',
+                name: 'Nodejs/Middleware/Koa/firstMiddleware//:first'
+              }]
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:first',
+          'transaction should be named after the matched path'
+        )
+        t.end()
+      })
+      run()
+    })
+
+    t.test('should name and produce segments for matched regex path', (t) => {
+      router.get(/.*rst$/, function firstMiddleware(ctx) {
+        ctx.body = 'first'
+      })
+      app.use(router.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//.*rst$',
+            children: [{
+              name: 'Koa/Router: /',
+              children: [{
+                name: 'Nodejs/Middleware/Koa/firstMiddleware//.*rst$/'
+              }]
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//.*rst$',
+          'transaction should be named after the matched regex pattern'
+        )
+        t.end()
+      })
+      run('/first')
+    })
+
+    t.test('should name and produce segments for matched regex path', (t) => {
+      router.get('/:first/(.*)', function firstMiddleware(ctx) {
+        ctx.body = 'first'
+      })
+      app.use(router.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first/(.*)',
+            children: [{
+              name: 'Koa/Router: /',
+              children: [{
+                name: 'Nodejs/Middleware/Koa/firstMiddleware//:first/(.*)'
+              }]
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:first/(.*)',
+          'transaction should be named after the matched regex path'
+        )
+        t.end()
+      })
+      run('/123/456')
+    })
+
+    t.test('should name and produce segments with router paramware', (t) => {
+      router.param('first', function firstParamware(id, ctx, next) {
+        ctx.body = 'first'
+        return next()
+      })
+      router.get('/:first', function firstMiddleware(ctx, next) {
+        return next()
+      })
+      app.use(router.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
+            children: [{
+              name: 'Koa/Router: /',
+              children: [{
+                name: paramMiddlewareName,
+                children: [{
+                  name: 'Nodejs/Middleware/Koa/firstParamware//[param handler :first]',
+                  children: [{
+                    name: 'Nodejs/Middleware/Koa/firstMiddleware//:first'
+                  }]
+                }]
+              }]
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:first',
+          'transaction should be named after the matched path'
+        )
+        t.end()
+      })
+      run()
+    })
+
+    t.test('should name transaction after matched path with erroring parameware', (t) => {
+      router.param('first', function firstParamware() {
+        throw new Error('wrong param')
+      })
+      router.get('/:first', function firstMiddleware() {})
+
+      app.use(router.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
+            children: [{
+              name: 'Koa/Router: /',
+              children: [{
+                name: paramMiddlewareName,
+                children: [{
+                  name: 'Nodejs/Middleware/Koa/firstParamware//[param handler :first]'
+                }]
+              }]
+            }]
+          }],
+          'should have expected segments'
+        )
+        const errors = helper.agent.errors.errors
+        t.equal(errors.length, 1, 'the error has been recorded')
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:first',
+          'transaction should be named after the matched path'
+        )
+        t.end()
+      })
+      run()
+    })
+
+    t.test('should name the transaction after the last matched path (layer)', (t) => {
+      router.get('/:first', function firstMiddleware(ctx, next) {
+        ctx.body = 'first'
+        return next().then(function someMoreContent() {
+          ctx.body = 'first'
+        })
+      })
+      router.get('/:second', function secondMiddleware(ctx) {
+        ctx.body += ' second'
+      })
+
+      app.use(router.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:second',
+            children: [{
+              name: 'Koa/Router: /',
+              children: [{
+                name: 'Nodejs/Middleware/Koa/firstMiddleware//:first',
+                children: [{
+                  name: 'Nodejs/Middleware/Koa/secondMiddleware//:second'
+                }]
+              }]
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:second',
+          'transaction should be named after the matched path'
+        )
+        t.end()
+      })
+      run()
+    })
+
+    t.test('tx name should not be named after error handling middleware', (t) => {
+      app.use(function errorHandler(ctx, next) {
+        return next().catch((err) => {
+          ctx.body = { err: err.message }
+        })
+      })
+
+      router.get('/:first', function firstMiddleware(ctx) {
+        ctx.throw(400, '☃')
+      })
+
+      app.use(router.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
+            children: [{
+              name: 'Nodejs/Middleware/Koa/errorHandler',
+              children: [{
+                name: 'Koa/Router: /',
                 children: [{
                   name: 'Nodejs/Middleware/Koa/firstMiddleware//:first'
                 }]
               }]
             }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:first',
-        'transaction should be named after the matched path'
-      )
-      t.end()
+          }],
+          'should have expected segments'
+        )
+        const errors = helper.agent.errors.errors
+        t.equal(errors.length, 0, 'should not record error')
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:first',
+          'transaction should be named after the matched layer path'
+        )
+        t.end()
+      })
+      run()
     })
-    run()
-  })
 
-  t.test('should name transaction after matched path with erroring parameware', (t) => {
-    router.param('first', function firstParamware() {
-      throw new Error('wrong param')
-    })
-    router.get('/:first', function firstMiddleware() {})
+    t.test('transaction name should not be affected by unhandled error', (t) => {
+      app.use(function errorHandler(ctx, next) {
+        return next()
+      })
 
-    app.use(router.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
-          children: [{
-            name: 'Koa/Router: /',
+      router.get('/:first', function firstMiddleware(ctx) {
+        ctx.throw(400, '☃')
+      })
+
+      app.use(router.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
             children: [{
-              name: paramMiddlewareName,
+              name: 'Nodejs/Middleware/Koa/errorHandler',
               children: [{
-                name: 'Nodejs/Middleware/Koa/firstParamware//[param handler :first]'
+                name: 'Koa/Router: /',
+                children: [{
+                  name: 'Nodejs/Middleware/Koa/firstMiddleware//:first'
+                }]
               }]
             }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      const errors = helper.agent.errors.errors
-      t.equal(errors.length, 1, 'the error has been recorded')
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:first',
-        'transaction should be named after the matched path'
-      )
-      t.end()
+          }],
+          'should have expected segments'
+        )
+        const errors = helper.agent.errors.errors
+        t.equal(errors.length, 1, 'error should be recorded')
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:first',
+          'transaction should be named after the matched layer path'
+        )
+        t.end()
+      })
+      run()
     })
-    run()
+
+    t.test('should name tx after route declarations with supported http methods', (t) => {
+      // This will register the same middleware (i.e. secondMiddleware)
+      // under both the /:first and /:second routes. Use does not register middleware
+      // w/ supported methods they cannot handle routes.
+      router.use(['/:first', '/:second'], function secondMiddleware(ctx, next) {
+        ctx.body += ' second'
+        return next()
+      })
+      router.get('/:second', function terminalMiddleware(ctx) {
+        ctx.body = ' second'
+      })
+      app.use(router.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:second',
+            children: [{
+              name: 'Koa/Router: /',
+              children: [{
+                name: 'Nodejs/Middleware/Koa/secondMiddleware//:first',
+                children: [{
+                  name: 'Nodejs/Middleware/Koa/secondMiddleware//:second',
+                  children: [{
+                    name: 'Nodejs/Middleware/Koa/terminalMiddleware//:second'
+                  }]
+                }]
+              }]
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:second',
+          'transaction should be named after the last matched path'
+        )
+        t.end()
+      })
+      run()
+    })
+
+    t.test('names transaction (not found) with array of paths and no handler', (t) => {
+      // This will register the same middleware (i.e. secondMiddleware)
+      // under both the /:first and /:second routes.
+      router.use(['/:first', '/:second'], function secondMiddleware(ctx, next) {
+        ctx.body += ' second'
+        return next()
+      })
+      app.use(router.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET/(not found)',
+            children: [{
+              name: 'Koa/Router: /'
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET/(not found)',
+          'transaction should be named (not found)'
+        )
+        t.end()
+      })
+      run()
+    })
   })
 
-  t.test('should name the transaction after the last matched path (layer)', (t) => {
-    router.get('/:first', function firstMiddleware(ctx, next) {
-      ctx.body = 'first'
-      return next().then(function someMoreContent() {
+  t.test('using multipler routers', (t) => {
+    t.beforeEach((done) => testSetup(done))
+    t.afterEach((done) => tearDown(done))
+    t.autoend()
+
+    t.test('should name transaction after last route for identical matches', (t) => {
+      Router = require('koa-router')
+      const router2 = new Router()
+      router.get('/:first', function firstMiddleware(ctx, next) {
+        ctx.body = 'first'
+        return next()
+      })
+
+      router2.get('/:second', function secondMiddleware(ctx) {
+        ctx.body += ' second'
+      })
+      app.use(router.routes())
+      app.use(router2.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        // NOTE: due to an implementation detail in koa-compose,
+        // sequential middleware will show up as nested. This is due to
+        // the dispatch function blocking its returned promise on the
+        // resolution of a recursively returned promise.
+        // https://github.com/koajs/compose/blob/e754ca3c13e9248b3f453d98ea0b618e09578e2d/index.js#L42-L44
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:second',
+            children: [{
+              name: 'Koa/Router: /',
+              children: [{
+                name: 'Nodejs/Middleware/Koa/firstMiddleware//:first',
+                children: [{
+                  name: 'Koa/Router: /',
+                  children: [{
+                    name: 'Nodejs/Middleware/Koa/secondMiddleware//:second'
+                  }]
+                }]
+              }]
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:second',
+          'transaction should be named after the most specific matched path'
+        )
+        t.end()
+      })
+      run()
+    })
+
+    t.test('should name tx after last matched route even if body not set', (t) => {
+      Router = require('koa-router')
+      const router2 = new Router()
+      router.get('/first', function firstMiddleware(ctx, next) {
+        ctx.body = 'first'
+        return next()
+      })
+
+      router2.get('/:second', function secondMiddleware() {})
+      app.use(router.routes())
+      app.use(router2.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        // NOTE: due to an implementation detail in koa-compose,
+        // sequential middleware will show up as nested. This is due to
+        // the dispatch function blocking its returned promise on the
+        // resolution of a recursively returned promise.
+        // https://github.com/koajs/compose/blob/e754ca3c13e9248b3f453d98ea0b618e09578e2d/index.js#L42-L44
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:second',
+            children: [{
+              name: 'Koa/Router: /',
+              children: [{
+                name: 'Nodejs/Middleware/Koa/firstMiddleware//first',
+                children: [{
+                  name: 'Koa/Router: /',
+                  children: [{
+                    name: 'Nodejs/Middleware/Koa/secondMiddleware//:second'
+                  }]
+                }]
+              }]
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:second',
+          'transaction should be named after the last matched path'
+        )
+        t.end()
+      })
+      run('/first')
+    })
+  })
+
+  t.test('using nested or prefixed routers', (t) => {
+    t.beforeEach((done) => testSetup(done))
+    t.afterEach((done) => tearDown(done))
+    t.autoend()
+
+    t.test('should name after most last matched path', (t) => {
+      var router2 = new Router()
+      router2.get('/:second', function secondMiddleware(ctx) {
+        ctx.body = ' second'
+      })
+      router.use('/:first', router2.routes())
+      app.use(router.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first/:second',
+            children: [{
+              name: 'Koa/Router: /',
+              children: [{
+                name: 'Nodejs/Middleware/Koa/secondMiddleware//:first/:second'
+              }]
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:first/:second',
+          'transaction should be named after the last matched path'
+        )
+        t.end()
+      })
+      run('/123/456/')
+    })
+
+    t.test('app-level middleware should not rename tx from matched path', (t) => {
+      app.use(function appLevelMiddleware(ctx, next) {
+        return next().then(() => {
+          ctx.body = 'do not want this to set the name'
+        })
+      })
+
+      const nestedRouter = new Router()
+      nestedRouter.get('/:second', function terminalMiddleware(ctx) {
+        ctx.body = 'this is a test'
+      })
+      nestedRouter.get('/second', function secondMiddleware(ctx) {
+        ctx.body = 'want this to set the name'
+      })
+      router.use('/:first', nestedRouter.routes())
+      app.use(router.routes())
+
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first/second',
+            children: [{
+              name: 'Nodejs/Middleware/Koa/appLevelMiddleware',
+              children: [{
+                name: 'Koa/Router: /',
+                children: [{
+                  name: 'Nodejs/Middleware/Koa/terminalMiddleware//:first/:second'
+                }]
+              }]
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:first/second',
+          'should be named after last matched route'
+        )
+        t.end()
+      })
+      run('/123/second')
+    })
+
+    t.test('app-level middleware should not rename tx from matched prefix path', (t) => {
+      app.use(function appLevelMiddleware(ctx, next) {
+        return next().then(() => {
+          ctx.body = 'do not want this to set the name'
+        })
+      })
+
+      router.get('/:second', function terminalMiddleware(ctx) {
+        ctx.body = 'this is a test'
+      })
+      router.get('/second', function secondMiddleware(ctx) {
+        ctx.body = 'want this to set the name'
+      })
+      router.prefix('/:first')
+      app.use(router.routes())
+
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first/second',
+            children: [{
+              name: 'Nodejs/Middleware/Koa/appLevelMiddleware',
+              children: [{
+                name: 'Koa/Router: /',
+                children: [{
+                  name: 'Nodejs/Middleware/Koa/terminalMiddleware//:first/:second'
+                }]
+              }]
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:first/second',
+          'should be named after the last matched path'
+        )
+        t.end()
+      })
+      run('/123/second')
+    })
+  })
+
+  t.test('using allowedMethods', (t) => {
+    t.beforeEach((done) => testSetup(done))
+    t.afterEach((done) => tearDown(done))
+    t.autoend()
+
+    t.test('should name transaction after `method now allowed` message', (t) => {
+      router.post('/:first', function firstMiddleware() {})
+      app.use(router.routes())
+      app.use(router.allowedMethods({throw: true}))
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)'
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
+          'transaction should be named after corresponding status code message'
+        )
+        const errors = helper.agent.errors.errors
+        t.equal(errors.length, 1, 'the error has been recorded')
+        t.end()
+      })
+      run()
+    })
+
+    t.test('should name transaction after `not implemented` message', (t) => {
+      router = new Router({ methods: ['POST'] })
+      router.post('/:first', function firstMiddleware() {})
+      app.use(router.routes())
+      app.use(router.allowedMethods())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET/(not implemented)'
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET/(not implemented)',
+          'transaction should be named after corresponding status code message'
+        )
+        // TODO: this seems wrong before of no {throw: true}
+        const errors = helper.agent.errors.errors
+        t.equal(errors.length, 1, 'the error has been recorded')
+        t.end()
+      })
+      run()
+    })
+
+    t.test('should name and produce segments for existing matched path', (t) => {
+      router = new Router({ methods: ['GET'] })
+      router.get('/:first', function firstMiddleware(ctx) {
         ctx.body = 'first'
       })
-    })
-    router.get('/:second', function secondMiddleware(ctx) {
-      ctx.body += ' second'
-    })
-
-    app.use(router.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:second',
-          children: [{
-            name: 'Koa/Router: /',
-            children: [{
-              name: 'Nodejs/Middleware/Koa/firstMiddleware//:first',
-              children: [{
-                name: 'Nodejs/Middleware/Koa/secondMiddleware//:second'
-              }]
-            }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:second',
-        'transaction should be named after the matched path'
-      )
-      t.end()
-    })
-    run()
-  })
-
-  t.test('transaction name should not be named after error handling middleware', (t) => {
-    app.use(function errorHandler(ctx, next) {
-      return next().catch((err) => {
-        ctx.body = { err: err.message }
-      })
-    })
-
-    router.get('/:first', function firstMiddleware(ctx) {
-      ctx.throw(400, '☃')
-    })
-
-    app.use(router.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
-          children: [{
-            name: 'Nodejs/Middleware/Koa/errorHandler',
+      app.use(router.routes())
+      app.use(router.allowedMethods())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
             children: [{
               name: 'Koa/Router: /',
               children: [{
                 name: 'Nodejs/Middleware/Koa/firstMiddleware//:first'
               }]
             }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      const errors = helper.agent.errors.errors
-      t.equal(errors.length, 0, 'should not record error')
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:first',
-        'transaction should be named after the matched layer path'
-      )
-      t.end()
-    })
-    run()
-  })
-
-  t.test('transaction name should not be affected by unhandled error', (t) => {
-    app.use(function errorHandler(ctx, next) {
-      return next()
-    })
-
-    router.get('/:first', function firstMiddleware(ctx) {
-      ctx.throw(400, '☃')
-    })
-
-    app.use(router.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first',
-          children: [{
-            name: 'Nodejs/Middleware/Koa/errorHandler',
-            children: [{
-              name: 'Koa/Router: /',
-              children: [{
-                name: 'Nodejs/Middleware/Koa/firstMiddleware//:first'
-              }]
-            }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      const errors = helper.agent.errors.errors
-      t.equal(errors.length, 1, 'error should be recorded')
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:first',
-        'transaction should be named after the matched layer path'
-      )
-      t.end()
-    })
-    run()
-  })
-
-  t.test('should name transaction after last route for identical matches', (t) => {
-    Router = require('koa-router')
-    const router2 = new Router()
-    router.get('/:first', function firstMiddleware(ctx, next) {
-      ctx.body = 'first'
-      return next()
-    })
-
-    router2.get('/:second', function secondMiddleware(ctx) {
-      ctx.body += ' second'
-    })
-    app.use(router.routes())
-    app.use(router2.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      // NOTE: due to an implementation detail in koa-compose,
-      // sequential middleware will show up as nested. This is due to
-      // the dispatch function blocking its returned promise on the
-      // resolution of a recursively returned promise.
-      // https://github.com/koajs/compose/blob/e754ca3c13e9248b3f453d98ea0b618e09578e2d/index.js#L42-L44
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:second',
-          children: [{
-            name: 'Koa/Router: /',
-            children: [{
-              name: 'Nodejs/Middleware/Koa/firstMiddleware//:first',
-              children: [{
-                name: 'Koa/Router: /',
-                children: [{
-                  name: 'Nodejs/Middleware/Koa/secondMiddleware//:second'
-                }]
-              }]
-            }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:second',
-        'transaction should be named after the most specific matched path'
-      )
-      t.end()
-    })
-    run()
-  })
-
-  t.test('should name tx after last matched route even if body not set', (t) => {
-    Router = require('koa-router')
-    const router2 = new Router()
-    router.get('/first', function firstMiddleware(ctx, next) {
-      ctx.body = 'first'
-      return next()
-    })
-
-    router2.get('/:second', function secondMiddleware() {})
-    app.use(router.routes())
-    app.use(router2.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      // NOTE: due to an implementation detail in koa-compose,
-      // sequential middleware will show up as nested. This is due to
-      // the dispatch function blocking its returned promise on the
-      // resolution of a recursively returned promise.
-      // https://github.com/koajs/compose/blob/e754ca3c13e9248b3f453d98ea0b618e09578e2d/index.js#L42-L44
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:second',
-          children: [{
-            name: 'Koa/Router: /',
-            children: [{
-              name: 'Nodejs/Middleware/Koa/firstMiddleware//first',
-              children: [{
-                name: 'Koa/Router: /',
-                children: [{
-                  name: 'Nodejs/Middleware/Koa/secondMiddleware//:second'
-                }]
-              }]
-            }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:second',
-        'transaction should be named after the last matched path'
-      )
-      t.end()
-    })
-    run('/first')
-  })
-
-  t.test('should name after most last matched path in nested router', (t) => {
-    var router2 = new Router()
-    router2.get('/:second', function secondMiddleware(ctx) {
-      ctx.body = ' second'
-    })
-    router.use('/:first', router2.routes())
-    app.use(router.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first/:second',
-          children: [{
-            name: 'Koa/Router: /',
-            children: [{
-              name: 'Nodejs/Middleware/Koa/secondMiddleware//:first/:second'
-            }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:first/:second',
-        'transaction should be named after the last matched path'
-      )
-      t.end()
-    })
-    run('/123/456/')
-  })
-
-  t.test('should name tx after route declarations with supported http methods', (t) => {
-    // This will register the same middleware (i.e. secondMiddleware)
-    // under both the /:first and /:second routes. Use does not register middleware
-    // w/ supported methods they cannot handle routes.
-    router.use(['/:first', '/:second'], function secondMiddleware(ctx, next) {
-      ctx.body += ' second'
-      return next()
-    })
-    router.get('/:second', function terminalMiddleware(ctx) {
-      ctx.body = ' second'
-    })
-    app.use(router.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:second',
-          children: [{
-            name: 'Koa/Router: /',
-            children: [{
-              name: 'Nodejs/Middleware/Koa/secondMiddleware//:first',
-              children: [{
-                name: 'Nodejs/Middleware/Koa/secondMiddleware//:second',
-                children: [{
-                  name: 'Nodejs/Middleware/Koa/terminalMiddleware//:second'
-                }]
-              }]
-            }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:second',
-        'transaction should be named after the last matched path'
-      )
-      t.end()
-    })
-    run()
-  })
-
-  t.test('names transaction (not found) with array of paths and no handler', (t) => {
-    // This will register the same middleware (i.e. secondMiddleware)
-    // under both the /:first and /:second routes.
-    router.use(['/:first', '/:second'], function secondMiddleware(ctx, next) {
-      ctx.body += ' second'
-      return next()
-    })
-    app.use(router.routes())
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET/(not found)',
-          children: [{
-            name: 'Koa/Router: /'
-          }]
-        }],
-        'should have expected segments'
-      )
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET/(not found)',
-        'transaction should be named (not found)'
-      )
-      t.end()
-    })
-    run()
-  })
-
-  t.test('app-level middleware should not rename tx from nested router', (t) => {
-    app.use(function appLevelMiddleware(ctx, next) {
-      return next().then(() => {
-        ctx.body = 'do not want this to set the name'
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET//:first',
+          'transaction should be named after the matched path'
+        )
+        t.end()
       })
+      run()
     })
 
-    const nestedRouter = new Router()
-    nestedRouter.get('/:second', function terminalMiddleware(ctx) {
-      ctx.body = 'this is a test'
-    })
-    nestedRouter.get('/second', function secondMiddleware(ctx) {
-      ctx.body = 'want this to set the name'
-    })
-    router.use('/:first', nestedRouter.routes())
-    app.use(router.routes())
-
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first/second',
-          children: [{
-            name: 'Nodejs/Middleware/Koa/appLevelMiddleware',
-            children: [{
-              name: 'Koa/Router: /',
-              children: [{
-                name: 'Nodejs/Middleware/Koa/terminalMiddleware//:first/:second'
-              }]
-            }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:first/second',
-        'should be named after last matched route'
-      )
-      t.end()
-    })
-    run('/123/second')
-  })
-
-  t.test('app-level middleware should not rename tx from prefixed router', (t) => {
-    app.use(function appLevelMiddleware(ctx, next) {
-      return next().then(() => {
-        ctx.body = 'do not want this to set the name'
+    t.test('should name tx from status code message', (t) => {
+      // This will register the same middleware (i.e. secondMiddleware)
+      // under both the /:first and /:second routes. Use does not register middleware
+      // w/ supported methods they cannot handle routes.
+      router.use(['/:first', '/:second'], function secondMiddleware(ctx, next) {
+        ctx.body += ' second'
+        return next()
       })
+      router.post('/:second', function terminalMiddleware(ctx) {
+        ctx.body = ' second'
+      })
+      app.use(router.routes())
+      app.use(router.allowedMethods({throw: true}))
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)'
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
+          'transaction should be named after the last matched path'
+        )
+        t.end()
+      })
+      run()
     })
 
-    router.get('/:second', function terminalMiddleware(ctx) {
-      ctx.body = 'this is a test'
-    })
-    router.get('/second', function secondMiddleware(ctx) {
-      ctx.body = 'want this to set the name'
-    })
-    router.prefix('/:first')
-    app.use(router.routes())
+    t.test('should name tx after `method not allowed` with prefixed router', (t) => {
+      app.use(function appLevelMiddleware(ctx, next) {
+        return next().then(() => {
+          ctx.body = 'should not set the same'
+        })
+      })
+      router.post('/second', function secondMiddleware(ctx) {
+        ctx.body = 'should not set the name'
+      })
+      router.prefix('/:first')
+      app.use(router.routes())
+      app.use(router.allowedMethods())
 
-    helper.agent.on('transactionFinished', (tx) => {
-      t.exactSegments(
-        tx.trace.root, [{
-          name: 'WebTransaction/WebFrameworkUri/Koa/GET//:first/second',
-          children: [{
-            name: 'Nodejs/Middleware/Koa/appLevelMiddleware',
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
             children: [{
-              name: 'Koa/Router: /',
-              children: [{
-                name: 'Nodejs/Middleware/Koa/terminalMiddleware//:first/:second'
-              }]
+              name: 'Nodejs/Middleware/Koa/appLevelMiddleware'
             }]
-          }]
-        }],
-        'should have expected segments'
-      )
-      t.equal(
-        tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//:first/second',
-        'should be named after the last matched path'
-      )
-      t.end()
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
+          'should be named after the last matched path'
+        )
+        t.end()
+      })
+      run('/123/second')
     })
-    run('/123/second')
   })
 
   t.autoend()

--- a/tests/versioned/koa-router.tap.js
+++ b/tests/versioned/koa-router.tap.js
@@ -40,12 +40,16 @@ tap.test('koa-router instrumentation', (t) => {
   }
 
   function tearDown(done) {
-    server.close()
-    app = null
-    router = null
-    Router = null
-    helper && helper.unload()
-    done()
+    server.close(() => {
+      app = null
+      router = null
+      Router = null
+      helper && helper.unload()
+
+      server = null
+
+      done()
+    })
   }
 
   t.test('with single router', (t) => {
@@ -68,8 +72,7 @@ tap.test('koa-router instrumentation', (t) => {
                 name: 'Nodejs/Middleware/Koa/firstMiddleware//:first'
               }]
             }]
-          }],
-          'should have expected segments'
+          }]
         )
         t.equal(
           tx.name,
@@ -96,8 +99,7 @@ tap.test('koa-router instrumentation', (t) => {
                 name: 'Nodejs/Middleware/Koa/firstMiddleware//.*rst$/'
               }]
             }]
-          }],
-          'should have expected segments'
+          }]
         )
         t.equal(
           tx.name,
@@ -124,8 +126,7 @@ tap.test('koa-router instrumentation', (t) => {
                 name: 'Nodejs/Middleware/Koa/firstMiddleware//:first/(.*)'
               }]
             }]
-          }],
-          'should have expected segments'
+          }]
         )
         t.equal(
           tx.name,
@@ -162,8 +163,7 @@ tap.test('koa-router instrumentation', (t) => {
                 }]
               }]
             }]
-          }],
-          'should have expected segments'
+          }]
         )
         t.equal(
           tx.name,
@@ -195,8 +195,7 @@ tap.test('koa-router instrumentation', (t) => {
                 }]
               }]
             }]
-          }],
-          'should have expected segments'
+          }]
         )
         const errors = helper.agent.errors.errors
         t.equal(errors.length, 1, 'the error has been recorded')
@@ -235,8 +234,7 @@ tap.test('koa-router instrumentation', (t) => {
                 }]
               }]
             }]
-          }],
-          'should have expected segments'
+          }]
         )
         t.equal(
           tx.name,
@@ -273,8 +271,7 @@ tap.test('koa-router instrumentation', (t) => {
                 }]
               }]
             }]
-          }],
-          'should have expected segments'
+          }]
         )
         const errors = helper.agent.errors.errors
         t.equal(errors.length, 0, 'should not record error')
@@ -311,8 +308,7 @@ tap.test('koa-router instrumentation', (t) => {
                 }]
               }]
             }]
-          }],
-          'should have expected segments'
+          }]
         )
         const errors = helper.agent.errors.errors
         t.equal(errors.length, 1, 'error should be recorded')
@@ -354,8 +350,7 @@ tap.test('koa-router instrumentation', (t) => {
                 }]
               }]
             }]
-          }],
-          'should have expected segments'
+          }]
         )
         t.equal(
           tx.name,
@@ -382,8 +377,7 @@ tap.test('koa-router instrumentation', (t) => {
             children: [{
               name: 'Koa/Router: /'
             }]
-          }],
-          'should have expected segments'
+          }]
         )
         t.equal(
           tx.name,
@@ -393,6 +387,33 @@ tap.test('koa-router instrumentation', (t) => {
         t.end()
       })
       run()
+    })
+
+    t.test('names transaction (not found) with base middleware that does not set body and no matching route', (t) => {
+      app.use((ctx, next) => {
+        next()
+      })
+
+      // This will register the same middleware (i.e. secondMiddleware)
+      // under both the /:first and /:second routes.
+      router.get('/first', function secondMiddleware(ctx) {
+        ctx.body = 'first'
+      })
+      app.use(router.routes())
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET/(not found)'
+          }]
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET/(not found)',
+          'transaction should be named (not found)'
+        )
+        t.end()
+      })
+      run('/')
     })
   })
 
@@ -435,8 +456,7 @@ tap.test('koa-router instrumentation', (t) => {
                 }]
               }]
             }]
-          }],
-          'should have expected segments'
+          }]
         )
         t.equal(
           tx.name,
@@ -480,8 +500,7 @@ tap.test('koa-router instrumentation', (t) => {
                 }]
               }]
             }]
-          }],
-          'should have expected segments'
+          }]
         )
         t.equal(
           tx.name,
@@ -494,6 +513,8 @@ tap.test('koa-router instrumentation', (t) => {
     })
   })
 
+  // TODO: appears segment pathing negativelh impacted by recent changes
+  // perhaps the removal of accidental appending
   t.test('using nested or prefixed routers', (t) => {
     t.beforeEach((done) => testSetup(done))
     t.afterEach((done) => tearDown(done))
@@ -516,8 +537,7 @@ tap.test('koa-router instrumentation', (t) => {
                 name: 'Nodejs/Middleware/Koa/secondMiddleware//:first/:second'
               }]
             }]
-          }],
-          'should have expected segments'
+          }]
         )
         t.equal(
           tx.name,
@@ -559,8 +579,7 @@ tap.test('koa-router instrumentation', (t) => {
                 }]
               }]
             }]
-          }],
-          'should have expected segments'
+          }]
         )
         t.equal(
           tx.name,
@@ -601,8 +620,7 @@ tap.test('koa-router instrumentation', (t) => {
                 }]
               }]
             }]
-          }],
-          'should have expected segments'
+          }]
         )
         t.equal(
           tx.name,
@@ -614,6 +632,9 @@ tap.test('koa-router instrumentation', (t) => {
       run('/123/second')
     })
   })
+
+
+  // TODO: check/update segments for everything
 
   t.test('using allowedMethods', (t) => {
     t.beforeEach((done) => testSetup(done))
@@ -628,8 +649,7 @@ tap.test('koa-router instrumentation', (t) => {
         t.exactSegments(
           tx.trace.root, [{
             name: 'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)'
-          }],
-          'should have expected segments'
+          }]
         )
         t.equal(
           tx.name,
@@ -652,8 +672,7 @@ tap.test('koa-router instrumentation', (t) => {
         t.exactSegments(
           tx.trace.root, [{
             name: 'WebTransaction/WebFrameworkUri/Koa/GET/(not implemented)'
-          }],
-          'should have expected segments'
+          }]
         )
         t.equal(
           tx.name,
@@ -685,8 +704,7 @@ tap.test('koa-router instrumentation', (t) => {
                 name: 'Nodejs/Middleware/Koa/firstMiddleware//:first'
               }]
             }]
-          }],
-          'should have expected segments'
+          }]
         )
         t.equal(
           tx.name,
@@ -715,8 +733,7 @@ tap.test('koa-router instrumentation', (t) => {
         t.exactSegments(
           tx.trace.root, [{
             name: 'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)'
-          }],
-          'should have expected segments'
+          }]
         )
         t.equal(
           tx.name,
@@ -729,9 +746,15 @@ tap.test('koa-router instrumentation', (t) => {
     })
 
     t.test('should name tx after `method not allowed` with prefixed router', (t) => {
+      // TODO: oddly enough, the body set here is what screws things up
+      // We could set a property from allowed methods
+      // but that doesnt' explain why the case w/o allowedmethods and w/o setting body
+      // fails?
       app.use(function appLevelMiddleware(ctx, next) {
         return next().then(() => {
+          console.log(ctx.status)
           ctx.body = 'should not set the same'
+          console.log(ctx.status)
         })
       })
       router.post('/second', function secondMiddleware(ctx) {
@@ -748,8 +771,7 @@ tap.test('koa-router instrumentation', (t) => {
             children: [{
               name: 'Nodejs/Middleware/Koa/appLevelMiddleware'
             }]
-          }],
-          'should have expected segments'
+          }]
         )
         t.equal(
           tx.name,
@@ -761,6 +783,7 @@ tap.test('koa-router instrumentation', (t) => {
       run('/123/second')
     })
 
+    // TODO: setting the body results in status 200, so we name after that (which is normalized). fix test wording/commetn as necessary.
     t.test('error handler normalizes tx name if body is reset', (t) => {
       app.use(function errorHandler(ctx, next) {
         return next().catch(() => {
@@ -783,8 +806,7 @@ tap.test('koa-router instrumentation', (t) => {
             children: [{
               name: 'Nodejs/Middleware/Koa/errorHandler'
             }]
-          }],
-          'should have expected segments'
+          }]
         )
         t.equal(
           tx.name,
@@ -793,6 +815,45 @@ tap.test('koa-router instrumentation', (t) => {
         )
         const errors = helper.agent.errors.errors
         t.equal(errors.length, 0, 'error should not be recorded')
+        t.end()
+      })
+      run('/123/456')
+    })
+
+    t.test('should name tx after `method not allowed` with base middleware that does not set body', (t) => {
+      // Because allowedMethods throws & no user catching, it is considered
+      // unhandled and will push the base route back on
+
+      app.use(function errorHandler(ctx, next) {
+        return next()
+        // does not set ctx.body or ctx.status
+      })
+
+      const nestedRouter = new Router()
+      nestedRouter.post('/:second', function terminalMiddleware(ctx) {
+        ctx.body = 'would want this to set name if verb were correct'
+      })
+      router.use('/:first', nestedRouter.routes(), nestedRouter.allowedMethods())
+      app.use(router.routes())
+      app.use(router.allowedMethods({throw: true}))
+
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
+            children: [{
+              name: 'Nodejs/Middleware/Koa/errorHandler'
+            }]
+          }]
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
+          'should name after returned status code'
+        )
+        const errors = helper.agent.errors.errors
+        t.equal(errors.length, 1, 'should notice thrown error')
+
         t.end()
       })
       run('/123/456')
@@ -810,3 +871,7 @@ tap.test('koa-router instrumentation', (t) => {
     })
   }
 })
+
+// TODO: specific segment matching maybe doesnt' care about hings you omit
+// seems like we could also account for allowedMethods
+// maybe dispatch or some such. verify what all we instrument

--- a/tests/versioned/koa-router.tap.js
+++ b/tests/versioned/koa-router.tap.js
@@ -513,9 +513,6 @@ tap.test('koa-router instrumentation', (t) => {
     })
   })
 
-  // TODO: appears segment pathing negativelh impacted by recent changes
-  // perhaps the removal of accidental appending
-  // router.setPrefix() modifies the path of nested layers.
   t.test('using nested or prefixed routers', (t) => {
     t.beforeEach((done) => testSetup(done))
     t.afterEach((done) => tearDown(done))
@@ -680,7 +677,7 @@ tap.test('koa-router instrumentation', (t) => {
           'WebTransaction/WebFrameworkUri/Koa/GET/(not implemented)',
           'transaction should be named after corresponding status code message'
         )
-        // TODO: this seems wrong before of no {throw: true}
+        // TODO: this seems wrong because of no {throw: true}
         const errors = helper.agent.errors.errors
         t.equal(errors.length, 1, 'the error has been recorded')
         t.end()
@@ -747,15 +744,9 @@ tap.test('koa-router instrumentation', (t) => {
     })
 
     t.test('should name tx after `method not allowed` with prefixed router', (t) => {
-      // TODO: oddly enough, the body set here is what screws things up
-      // We could set a property from allowed methods
-      // but that doesnt' explain why the case w/o allowedmethods and w/o setting body
-      // fails?
       app.use(function appLevelMiddleware(ctx, next) {
         return next().then(() => {
-          console.log(ctx.status)
-          ctx.body = 'should not set the same'
-          console.log(ctx.status)
+          ctx.body = 'should not set the name'
         })
       })
       router.post('/second', function secondMiddleware(ctx) {

--- a/tests/versioned/koa-router.tap.js
+++ b/tests/versioned/koa-router.tap.js
@@ -760,6 +760,43 @@ tap.test('koa-router instrumentation', (t) => {
       })
       run('/123/second')
     })
+
+    t.test('error handler normalizes tx name if body is reset', (t) => {
+      app.use(function errorHandler(ctx, next) {
+        return next().catch(() => {
+          ctx.body = { msg: 'error is handled' }
+        })
+      })
+
+      const nestedRouter = new Router()
+      nestedRouter.post('/:second', function terminalMiddleware(ctx) {
+        ctx.body = 'would want this to set name if verb were correct'
+      })
+      router.use('/:first', nestedRouter.routes(), nestedRouter.allowedMethods())
+      app.use(router.routes())
+      app.use(router.allowedMethods({throw: true}))
+
+      helper.agent.on('transactionFinished', (tx) => {
+        t.exactSegments(
+          tx.trace.root, [{
+            name: 'WebTransaction/NormalizedUri/*',
+            children: [{
+              name: 'Nodejs/Middleware/Koa/errorHandler'
+            }]
+          }],
+          'should have expected segments'
+        )
+        t.equal(
+          tx.name,
+          'WebTransaction/NormalizedUri/*',
+          'should have normalized transaction name'
+        )
+        const errors = helper.agent.errors.errors
+        t.equal(errors.length, 0, 'error should not be recorded')
+        t.end()
+      })
+      run('/123/456')
+    })
   })
 
   t.autoend()

--- a/tests/versioned/koa-router.tap.js
+++ b/tests/versioned/koa-router.tap.js
@@ -389,32 +389,41 @@ tap.test('koa-router instrumentation', (t) => {
       run()
     })
 
-    t.test('names transaction (not found) with base middleware that does not set body and no matching route', (t) => {
-      app.use((ctx, next) => {
-        next()
-      })
+    t.test(
+      'names tx (not found) when no matching route and base middleware does not set body',
+      (t) => {
+        app.use(function baseMiddleware(ctx, next) {
+          next()
+        })
 
-      // This will register the same middleware (i.e. secondMiddleware)
-      // under both the /:first and /:second routes.
-      router.get('/first', function secondMiddleware(ctx) {
-        ctx.body = 'first'
-      })
-      app.use(router.routes())
-      helper.agent.on('transactionFinished', (tx) => {
-        t.exactSegments(
-          tx.trace.root, [{
-            name: 'WebTransaction/WebFrameworkUri/Koa/GET/(not found)'
-          }]
-        )
-        t.equal(
-          tx.name,
-          'WebTransaction/WebFrameworkUri/Koa/GET/(not found)',
-          'transaction should be named (not found)'
-        )
-        t.end()
-      })
-      run('/')
-    })
+        // This will register the same middleware (i.e. secondMiddleware)
+        // under both the /:first and /:second routes.
+        router.get('/first', function secondMiddleware(ctx) {
+          ctx.body = 'first'
+        })
+        app.use(router.routes())
+        helper.agent.on('transactionFinished', (tx) => {
+          t.exactSegments(
+            tx.trace.root, [{
+              name: 'WebTransaction/WebFrameworkUri/Koa/GET/(not found)',
+              children: [{
+                name: 'Nodejs/Middleware/Koa/baseMiddleware',
+                children: [{
+                  name: 'Koa/Router: /'
+                }]
+              }]
+            }]
+          )
+          t.equal(
+            tx.name,
+            'WebTransaction/WebFrameworkUri/Koa/GET/(not found)',
+            'transaction should be named (not found)'
+          )
+          t.end()
+        })
+        run('/')
+      }
+    )
   })
 
   t.test('using multipler routers', (t) => {
@@ -631,9 +640,6 @@ tap.test('koa-router instrumentation', (t) => {
     })
   })
 
-
-  // TODO: check/update segments for everything
-
   t.test('using allowedMethods', (t) => {
     t.beforeEach((done) => testSetup(done))
     t.afterEach((done) => tearDown(done))
@@ -646,7 +652,13 @@ tap.test('koa-router instrumentation', (t) => {
       helper.agent.on('transactionFinished', (tx) => {
         t.exactSegments(
           tx.trace.root, [{
-            name: 'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)'
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
+            children: [{
+              name: 'Koa/Router: /',
+              children: [{
+                name: 'Nodejs/Middleware/Koa/allowedMethods'
+              }]
+            }]
           }]
         )
         t.equal(
@@ -669,7 +681,13 @@ tap.test('koa-router instrumentation', (t) => {
       helper.agent.on('transactionFinished', (tx) => {
         t.exactSegments(
           tx.trace.root, [{
-            name: 'WebTransaction/WebFrameworkUri/Koa/GET/(not implemented)'
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET/(not implemented)',
+            children: [{
+              name: 'Koa/Router: /',
+              children: [{
+                name: 'Nodejs/Middleware/Koa/allowedMethods'
+              }]
+            }]
           }]
         )
         t.equal(
@@ -730,7 +748,13 @@ tap.test('koa-router instrumentation', (t) => {
       helper.agent.on('transactionFinished', (tx) => {
         t.exactSegments(
           tx.trace.root, [{
-            name: 'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)'
+            name: 'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
+            children: [{
+              name: 'Koa/Router: /',
+              children: [{
+                name: 'Nodejs/Middleware/Koa/allowedMethods'
+              }]
+            }]
           }]
         )
         t.equal(
@@ -761,7 +785,13 @@ tap.test('koa-router instrumentation', (t) => {
           tx.trace.root, [{
             name: 'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
             children: [{
-              name: 'Nodejs/Middleware/Koa/appLevelMiddleware'
+              name: 'Nodejs/Middleware/Koa/appLevelMiddleware',
+              children: [{
+                name: 'Koa/Router: /',
+                children: [{
+                  name: 'Nodejs/Middleware/Koa/allowedMethods'
+                }]
+              }]
             }]
           }]
         )
@@ -775,10 +805,11 @@ tap.test('koa-router instrumentation', (t) => {
       run('/123/second')
     })
 
-    // TODO: setting the body results in status 200, so we name after that (which is normalized). fix test wording/commetn as necessary.
-    t.test('error handler normalizes tx name if body is reset', (t) => {
+    t.test('error handler normalizes tx name if body is reset without status', (t) => {
       app.use(function errorHandler(ctx, next) {
         return next().catch(() => {
+          // resetting the body without manually persisting ctx.status
+          // results in status 200
           ctx.body = { msg: 'error is handled' }
         })
       })
@@ -796,7 +827,13 @@ tap.test('koa-router instrumentation', (t) => {
           tx.trace.root, [{
             name: 'WebTransaction/NormalizedUri/*',
             children: [{
-              name: 'Nodejs/Middleware/Koa/errorHandler'
+              name: 'Nodejs/Middleware/Koa/errorHandler',
+              children: [{
+                name: 'Koa/Router: /',
+                children: [{
+                  name: 'Nodejs/Middleware/Koa/allowedMethods'
+                }]
+              }]
             }]
           }]
         )
@@ -812,44 +849,52 @@ tap.test('koa-router instrumentation', (t) => {
       run('/123/456')
     })
 
-    t.test('should name tx after `method not allowed` with base middleware that does not set body', (t) => {
-      // Because allowedMethods throws & no user catching, it is considered
-      // unhandled and will push the base route back on
+    t.test(
+      'should name tx after status message when base middleware does not set body',
+      (t) => {
+        // Because allowedMethods throws & no user catching, it is considered
+        // unhandled and will push the base route back on
+        app.use(function baseMiddleware(ctx, next) {
+          return next()
+          // does not set ctx.body or ctx.status
+        })
 
-      app.use(function errorHandler(ctx, next) {
-        return next()
-        // does not set ctx.body or ctx.status
-      })
+        const nestedRouter = new Router()
+        nestedRouter.post('/:second', function terminalMiddleware(ctx) {
+          ctx.body = 'would want this to set name if verb were correct'
+        })
+        router.use('/:first', nestedRouter.routes(), nestedRouter.allowedMethods())
+        app.use(router.routes())
+        app.use(router.allowedMethods({throw: true}))
 
-      const nestedRouter = new Router()
-      nestedRouter.post('/:second', function terminalMiddleware(ctx) {
-        ctx.body = 'would want this to set name if verb were correct'
-      })
-      router.use('/:first', nestedRouter.routes(), nestedRouter.allowedMethods())
-      app.use(router.routes())
-      app.use(router.allowedMethods({throw: true}))
-
-      helper.agent.on('transactionFinished', (tx) => {
-        t.exactSegments(
-          tx.trace.root, [{
-            name: 'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
-            children: [{
-              name: 'Nodejs/Middleware/Koa/errorHandler'
+        helper.agent.on('transactionFinished', (tx) => {
+          t.exactSegments(
+            tx.trace.root, [{
+              name: 'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
+              children: [{
+                name: 'Nodejs/Middleware/Koa/baseMiddleware',
+                children: [{
+                  name: 'Koa/Router: /',
+                  children: [{
+                    name: 'Nodejs/Middleware/Koa/allowedMethods'
+                  }]
+                }]
+              }]
             }]
-          }]
-        )
-        t.equal(
-          tx.name,
-          'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
-          'should name after returned status code'
-        )
-        const errors = helper.agent.errors.errors
-        t.equal(errors.length, 1, 'should notice thrown error')
+          )
+          t.equal(
+            tx.name,
+            'WebTransaction/WebFrameworkUri/Koa/GET/(method not allowed)',
+            'should name after returned status code'
+          )
+          const errors = helper.agent.errors.errors
+          t.equal(errors.length, 1, 'should notice thrown error')
 
-        t.end()
-      })
-      run('/123/456')
-    })
+          t.end()
+        })
+        run('/123/456')
+      }
+    )
   })
 
   t.autoend()
@@ -863,7 +908,3 @@ tap.test('koa-router instrumentation', (t) => {
     })
   }
 })
-
-// TODO: specific segment matching maybe doesnt' care about hings you omit
-// seems like we could also account for allowedMethods
-// maybe dispatch or some such. verify what all we instrument

--- a/tests/versioned/koa.tap.js
+++ b/tests/versioned/koa.tap.js
@@ -57,7 +57,29 @@ tap.test('Koa instrumentation', (t) => {
     run(t)
   })
 
-  // TODO: add test if don't set anything, defaults to status code...
+  t.test('Should name (not found) when no work is performed', (t) => {
+    t.plan(2)
+
+    app.use(function one(ctx, next) {
+      return next().then(() => {
+        // do nothing
+      })
+    })
+
+    app.use(function two() {
+      // do nothing
+    })
+
+    helper.agent.on('transactionFinished', (tx) => {
+      t.equal(
+        tx.name,
+        'WebTransaction/WebFrameworkUri/Koa/GET/(not found)',
+        'should name after status code message'
+      )
+    })
+
+    run(t, 'Not Found')
+  })
 
 
   t.test('names the transaction after the middleware that sets the body', (t) => {
@@ -86,8 +108,8 @@ tap.test('Koa instrumentation', (t) => {
   })
 
 
-  // TODO: how did these ever pass when originally looking for each appended path along the way?
-
+  // TODO: how did these ever pass when originally looking for each
+  // appended path along the way?
   t.test('names the transaction after the last middleware that sets the body', (t) => {
     t.plan(2)
 

--- a/tests/versioned/koa.tap.js
+++ b/tests/versioned/koa.tap.js
@@ -33,12 +33,38 @@ tap.test('Koa instrumentation', (t) => {
     done()
   })
 
+  t.test('Should name after koa framework and verb when body set', (t) => {
+    t.plan(2)
+
+    app.use(function one(ctx, next) {
+      return next().then(() => {
+        // do nothing
+      })
+    })
+
+    app.use(function two(ctx) {
+      ctx.body = 'done'
+    })
+
+    helper.agent.on('transactionFinished', (tx) => {
+      t.equal(
+        tx.name,
+        'WebTransaction/WebFrameworkUri/Koa/GET//',
+        'should have name without post-response name info'
+      )
+    })
+
+    run(t)
+  })
+
+  // TODO: add test if don't set anything, defaults to status code...
+
+
   t.test('names the transaction after the middleware that sets the body', (t) => {
     t.plan(2)
 
     app.use(function one(ctx, next) {
       const tx = helper.getTransaction()
-      tx.nameState.appendPath('one-start')
       return next().then(() => tx.nameState.appendPath('one-end'))
     })
 
@@ -51,7 +77,7 @@ tap.test('Koa instrumentation', (t) => {
     helper.agent.on('transactionFinished', (tx) => {
       t.equal(
         tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//one-start/two',
+        'WebTransaction/WebFrameworkUri/Koa/GET//two',
         'should have name without post-response name info'
       )
     })
@@ -59,12 +85,14 @@ tap.test('Koa instrumentation', (t) => {
     run(t)
   })
 
+
+  // TODO: how did these ever pass when originally looking for each appended path along the way?
+
   t.test('names the transaction after the last middleware that sets the body', (t) => {
     t.plan(2)
 
     app.use(function one(ctx, next) {
       const tx = helper.getTransaction()
-      tx.nameState.appendPath('one-start')
       return next().then(() => tx.nameState.appendPath('one-end'))
     })
 
@@ -84,7 +112,7 @@ tap.test('Koa instrumentation', (t) => {
     helper.agent.on('transactionFinished', (tx) => {
       t.equal(
         tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//one-start/two/three',
+        'WebTransaction/WebFrameworkUri/Koa/GET//three',
         'should have name without post-response name info'
       )
     })
@@ -97,7 +125,6 @@ tap.test('Koa instrumentation', (t) => {
 
     app.use(function one(ctx, next) {
       const tx = helper.getTransaction()
-      tx.nameState.appendPath('one-start')
       return next().then(() => tx.nameState.appendPath('one-end'))
     })
 
@@ -110,7 +137,7 @@ tap.test('Koa instrumentation', (t) => {
     helper.agent.on('transactionFinished', (tx) => {
       t.equal(
         tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//one-start/two',
+        'WebTransaction/WebFrameworkUri/Koa/GET//two',
         'should have name without post-response name info'
       )
     })
@@ -126,7 +153,6 @@ tap.test('Koa instrumentation', (t) => {
 
     app.use(function one(ctx, next) {
       const tx = helper.getTransaction()
-      tx.nameState.appendPath('one-start')
       return next().then(() => tx.nameState.appendPath('one-end'))
     })
 
@@ -142,7 +168,7 @@ tap.test('Koa instrumentation', (t) => {
     helper.agent.on('transactionFinished', (tx) => {
       t.equal(
         tx.name,
-        'WebTransaction/WebFrameworkUri/Koa/GET//one-start/two',
+        'WebTransaction/WebFrameworkUri/Koa/GET//two',
         'should have name without post-response name info'
       )
     })
@@ -393,7 +419,6 @@ function checkSegments(t, tx) {
           {name: 'Nodejs/Middleware/Koa/two'}
         ]
       }]
-    }],
-    'segments have expected names'
+    }]
   )
 }

--- a/tests/versioned/koa.tap.js
+++ b/tests/versioned/koa.tap.js
@@ -3,7 +3,6 @@
 const tap = require('tap')
 const utils = require('@newrelic/test-utilities')
 const http = require('http')
-const semver = require('semver')
 
 utils(tap)
 
@@ -238,49 +237,25 @@ tap.test('Koa instrumentation', (t) => {
     })
 
     helper.agent.on('transactionFinished', (tx) => {
-      // Node < 6 produces a different tx trace structure, due to differences
-      // in Promise implementation.
-      if (semver.lt(process.version, '6.0.0')) {
-        t.exactSegments(tx.trace.root, [
-          {
-            name: 'WebTransaction/WebFrameworkUri/Koa/GET//',
-            children: [{
-              name: 'Nodejs/Middleware/Koa/one',
-              children: [
-                {name: 'Truncated/testSegment'},
-                {
-                  name: 'Nodejs/Middleware/Koa/two',
-                  children: [
-                    {name: 'timers.setTimeout'},
-                    {name: 'Nodejs/Middleware/Koa/three'},
-                    {name: 'Truncated/nestedSegment'}
-                  ]
-                }
-              ]
-            }]
-          }
-        ])
-      } else {
-        t.exactSegments(tx.trace.root, [
-          {
-            name: 'WebTransaction/WebFrameworkUri/Koa/GET//',
-            children: [{
-              name: 'Nodejs/Middleware/Koa/one',
-              children: [
-                {name: 'Truncated/testSegment'},
-                {
-                  name: 'Nodejs/Middleware/Koa/two',
-                  children: [
-                    {name: 'timers.setTimeout'},
-                    {name: 'Nodejs/Middleware/Koa/three'}
-                  ]
-                },
-                {name: 'Truncated/nestedSegment'}
-              ]
-            }]
-          }
-        ])
-      }
+      t.exactSegments(tx.trace.root, [
+        {
+          name: 'WebTransaction/WebFrameworkUri/Koa/GET//',
+          children: [{
+            name: 'Nodejs/Middleware/Koa/one',
+            children: [
+              {name: 'Truncated/testSegment'},
+              {
+                name: 'Nodejs/Middleware/Koa/two',
+                children: [
+                  {name: 'timers.setTimeout'},
+                  {name: 'Nodejs/Middleware/Koa/three'}
+                ]
+              },
+              {name: 'Truncated/nestedSegment'}
+            ]
+          }]
+        }
+      ])
     })
 
     run(t)

--- a/tests/versioned/koa.tap.js
+++ b/tests/versioned/koa.tap.js
@@ -106,9 +106,6 @@ tap.test('Koa instrumentation', (t) => {
     run(t)
   })
 
-
-  // TODO: how did these ever pass when originally looking for each
-  // appended path along the way?
   t.test('names the transaction after the last middleware that sets the body', (t) => {
     t.plan(2)
 


### PR DESCRIPTION
## CHANGELOG

* Moved router-specific logic to koa-router instrumentation.

* Added `allowedMethods` middleware coverage.

* Fixed issue where `koa` middleware instrumentation did not accurately track `next` method which could impact custom transaction naming and router framework naming, in certain situations.

## INTERNAL LINKS

## NOTES

Still a couple remaining TODOs for consideration.
