### PR TITLE
NODE-2169 Adds Node 12 support. Drops Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,16 @@
 language: node_js
 node_js:
-  - "6"
-  - "7"
   - "8"
-  - "9"
   - "10"
+  - "12"
 env:
   - SUITE=lint
   - SUITE=unit
   - SUITE=versioned
 matrix:
   exclude:
-    - node_js: "6"
+    - node_js: "8"
       env: SUITE=lint
-    - node_js: "7"
+    - node_js: "10"
       env: SUITE=lint
 script: npm run $SUITE

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "New Relic Node.js agent team <nodejs@newrelic.com>",
   "license": "SEE LICENSE IN LICENSE",
   "engines": {
-    "node": ">=6.0.0 <11.0.0"
+    "node": ">=8.0.0"
   },
   "devDependencies": {
     "@koa/router": "^8.0.0",
@@ -26,14 +26,14 @@
     "koa": "^2.6.1",
     "koa-route": "^3.2.0",
     "koa-router": "^7.4.0",
-    "newrelic": "^5.9.0",
+    "newrelic": "^5.13.0",
     "semver": "^5.6.0",
-    "tap": "^12.0.1"
+    "tap": "^14.7.1"
   },
   "dependencies": {
     "methods": "^1.1.2"
   },
   "peerDependencies": {
-    "newrelic": ">=5.9.0"
+    "newrelic": ">=5.13.0"
   }
 }

--- a/tests/versioned/koa-router.tap.js
+++ b/tests/versioned/koa-router.tap.js
@@ -2,7 +2,6 @@
 
 const tap = require('tap')
 const utils = require('@newrelic/test-utilities')
-const semver = require('semver')
 const http = require('http')
 
 utils(tap)
@@ -13,12 +12,8 @@ tap.test('koa-router instrumentation', (t) => {
   let server = null
   let router = null
   let Router = null
-  let paramMiddlewareName
-  if (semver.satisfies(process.version, '>=6.0.0')) {
-    paramMiddlewareName = 'Nodejs/Middleware/Koa/middleware//:first'
-  } else {
-    paramMiddlewareName = 'Nodejs/Middleware/Koa/<anonymous>//:first'
-  }
+
+  const paramMiddlewareName = 'Nodejs/Middleware/Koa/middleware//:first'
 
   function testSetup(done) {
     helper = utils.TestAgent.makeInstrumented()
@@ -1028,12 +1023,8 @@ tap.test('@koa/router instrumentation', (t) => {
   let server = null
   let router = null
   let Router = null
-  let paramMiddlewareName
-  if (semver.satisfies(process.version, '>=6.0.0')) {
-    paramMiddlewareName = 'Nodejs/Middleware/Koa/middleware//:first'
-  } else {
-    paramMiddlewareName = 'Nodejs/Middleware/Koa/<anonymous>//:first'
-  }
+
+  const paramMiddlewareName = 'Nodejs/Middleware/Koa/middleware//:first'
 
   function testSetup(done) {
     helper = utils.TestAgent.makeInstrumented()

--- a/tests/versioned/koa.tap.js
+++ b/tests/versioned/koa.tap.js
@@ -258,51 +258,49 @@ tap.test('Koa instrumentation', (t) => {
     run(t)
   })
 
-  // THIS TEST WILL ONLY PASS IN CASES WHEN { await_support: true }.
-  // TRANSACTION CONTEXT IS NOT MAINTAINED BELOW NODE 8, AND REQUIRES
-  // CHANGES TO THE PROMISE INSTRUMENTATION.
-  //
-  // t.test('maintains transaction state between middleware', (t) => {
-  //   var tasks = []
-  //   var intervalId = setInterval(function() {
-  //     while (tasks.length) {
-  //       tasks.pop()()
-  //     }
-  //   }, 10)
+  t.test('maintains transaction state between middleware', (t) => {
+    t.plan(5)
 
-  //   t.tearDown(function() {
-  //     clearInterval(intervalId)
-  //   })
-  //   var tx
+    var tasks = []
+    var intervalId = setInterval(function() {
+      while (tasks.length) {
+        tasks.pop()()
+      }
+    }, 10)
 
-  //   app.use(function one(ctx, next) {
-  //     tx = helper.agent.getTransaction()
-  //     return new Promise(executor)
+    t.tearDown(function() {
+      clearInterval(intervalId)
+    })
+    var tx
 
-  //     function executor(resolve) {
-  //       tasks.push(function() {
-  //         next().then(function() {
-  //           t.transaction(tx)
-  //           resolve()
-  //         })
-  //       })
-  //     }
-  //   })
-  //   app.use(function two(ctx, next) {
-  //     t.transaction(tx, 'two has transaction context')
-  //     return next()
-  //   })
-  //   app.use(function three(ctx) {
-  //     t.transaction(tx, 'three has transaction context')
-  //     ctx.body = 'done'
-  //   })
+    app.use(function one(ctx, next) {
+      tx = helper.agent.getTransaction()
+      return new Promise(executor)
 
-  //   helper.agent.on('transactionFinished', function(txn) {
-  //     checkSegments(t, txn)
-  //   })
+      function executor(resolve) {
+        tasks.push(function() {
+          next().then(function() {
+            t.transaction(tx)
+            resolve()
+          })
+        })
+      }
+    })
+    app.use(function two(ctx, next) {
+      t.transaction(tx, 'two has transaction context')
+      return next()
+    })
+    app.use(function three(ctx) {
+      t.transaction(tx, 'three has transaction context')
+      ctx.body = 'done'
+    })
 
-  //   run(t)
-  // })
+    helper.agent.on('transactionFinished', function(txn) {
+      checkSegments(t, txn)
+    })
+
+    run(t)
+  })
 
   t.test('errors handled within middleware are not recorded', (t) => {
     t.plan(4)

--- a/tests/versioned/package.json
+++ b/tests/versioned/package.json
@@ -5,7 +5,7 @@
   "tests": [
     {
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       },
       "dependencies": {
         "koa": "^1.5.0"
@@ -21,7 +21,7 @@
     },
     {
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       },
       "dependencies": {
         "koa": ">=2.0.0"
@@ -32,7 +32,7 @@
     },
     {
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       },
       "dependencies": {
         "koa": ">=2.0.0",
@@ -45,7 +45,7 @@
     },
     {
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       },
       "dependencies": {
         "koa": ">=2.0.0",


### PR DESCRIPTION
## CHANGELOG
* **BREAKING** Removed support for Node 6, 7, and 9.

  The minimum supported version is now Node v8. For further information on our support policy, see: https://docs.newrelic.com/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.

* Added support for Node v12.

* Bumps `tap` to latest major version.

## INTERNAL LINKS

## NOTES

Uncommented that test that had a note about Node 8+. It did require adding an expected assertion count to end but seemed to work well.
