### PR TITLE
Null check for context.matched

### DIFF
--- a/lib/instrumentation.js
+++ b/lib/instrumentation.js
@@ -132,6 +132,11 @@ function wrapCreateContext(shim, fn, fnName, context) {
 }
 
 function getLayerForTransactionName(context) {
+  // Context.matched might be null
+  // See https://github.com/newrelic/node-newrelic-koa/pull/29
+  if (!context.matched) {
+    return null
+  }
   for (let i = context.matched.length - 1; i >= 0; i--) {
     const layer = context.matched[i]
     if (layer.opts.end) {


### PR DESCRIPTION
We are using fast-koa-router that set's _matchedRoute but does not set context.matched.
See https://github.com/nikostoulas/fast-koa-router/blob/master/src/router.ts#L12
Updating to latest newrelic library breaks our apps.

## CHANGELOG

## INTERNAL LINKS

## NOTES
