### PR TITLE
fix: add repo to package.json and @koa/router to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ require('@newrelic/koa')
 ### Supported routing modules
 
 - `koa-router`
+- `@koa/router`
 - `koa-route`
 
 For more information, please see the agent [installation guide][3], and

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
   },
   "author": "New Relic Node.js agent team <nodejs@newrelic.com>",
   "license": "SEE LICENSE IN LICENSE",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/newrelic/node-newrelic-koa"
+  },
   "engines": {
     "node": ">=8.0.0"
   },


### PR DESCRIPTION
## CHANGELOG

* Add `@koa/router` to README
* Add repository to package.json

## INTERNAL LINKS

## NOTES

* Fixes running `npm repo` or `npm info`, as well as missing repo link [here](https://www.npmjs.com/package/@newrelic/koa).
* Adds note that `@koa/router` is supported.