### PR TITLE
Add repository prop to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,9 @@
   },
   "peerDependencies": {
     "newrelic": ">=5.13.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/newrelic/node-newrelic-koa.git"
   }
 }

--- a/tests/versioned/package.json
+++ b/tests/versioned/package.json
@@ -36,8 +36,8 @@
       },
       "dependencies": {
         "koa": ">=2.0.0",
-        "@koa/router": ">=8.0.0",
-        "koa-router": ">=7.1.0"
+        "@koa/router": ">=8.0.0 <=8.0.2",
+        "koa-router": ">=7.1.0 <=8.0.2"
       },
       "files": [
         "koa-router.tap.js"


### PR DESCRIPTION
## CHANGELOG

* Adds repository property to package.json

* Limits `koa-router` and `@koa/router` tests to below versions with known naming issues (8.0.3+).

## INTERNAL LINKS

## NOTES
