### PR TITLE
Adds third party notices, bumps deps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ issues](../../issues?q=is%3Aissue+is%3Aclosed+label%3Aenhancement).
 
 ### Pull Requests
 
-We can only accept PRs for version v3.1.0 or greater due to open source
+We can only accept PRs for version v4.0.0 or greater due to open source
 licensing restrictions.
 
 ### Code of Conduct

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,537 @@
+# Third Party Notices
+
+The New Relic Koa Instrumentation uses source code from third party libraries which carry
+their own copyright notices and license terms. These notices are provided
+below.
+
+In the event that a required notice is missing or incorrect, please notify us
+by e-mailing [open-source@newrelic.com](mailto:open-source@newrelic.com).
+
+For any licenses that require the disclosure of source
+code, the source code can be found at [https://github.com/newrelic/node-newrelic-koa](https://github.com/newrelic/node-newrelic-koa).
+
+## Content
+
+**[dependencies](#dependencies)**
+
+* [methods](#methods)
+
+**[devDependencies](#devDependencies)**
+
+* [@koa/router](#koarouter)
+* [@newrelic/test-utilities](#newrelictest-utilities)
+* [coveralls](#coveralls)
+* [eslint](#eslint)
+* [koa-route](#koa-route)
+* [koa-router](#koa-router)
+* [koa](#koa)
+* [newrelic](#newrelic)
+* [semver](#semver)
+* [tap](#tap)
+
+
+## dependencies
+
+### methods
+
+This product includes source derived from [methods](https://github.com/jshttp/methods) ([v1.1.2](https://github.com/jshttp/methods/tree/v1.1.2)), distributed under the [MIT License](https://github.com/jshttp/methods/blob/v1.1.2/LICENSE):
+
+```
+(The MIT License)
+
+Copyright (c) 2013-2014 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2015-2016 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+```
+
+
+## devDependencies
+
+### @koa/router
+
+This product includes source derived from [@koa/router](https://github.com/koajs/koa-router) ([v8.0.5](https://github.com/koajs/koa-router/tree/v8.0.5)), distributed under the [MIT License](https://github.com/koajs/koa-router/blob/v8.0.5/LICENSE):
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2015 Alexander C. Mingoia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+```
+
+### @newrelic/test-utilities
+
+This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v3.0.0](https://github.com/newrelic/node-test-utilities/tree/v3.0.0)), distributed under the [proprietary License](https://github.com/newrelic/node-newrelic/blob/v6.10.0/LICENSE):
+
+```
+All components of this product are Copyright (c) 2016 New Relic, Inc.  All
+rights reserved.
+
+Certain inventions disclosed in this file may be claimed within patents owned or
+patent applications filed by New Relic, Inc. or third parties.
+
+Subject to the terms of this notice, New Relic grants you a nonexclusive,
+nontransferable license, without the right to sublicense, to (a) install and
+execute one copy of these files on any number of workstations owned or
+controlled by you and (b) distribute verbatim copies of these files to third
+parties.  You may install, execute, and distribute these files and their
+contents only in conjunction with your direct use of New Relic’s services.
+These files and their contents shall not be used in conjunction with any other
+product or software, including but not limited to those that may compete with
+any New Relic product, feature, or software. As a condition to the foregoing
+grant, you must provide this notice along with each copy you distribute and you
+must not remove, alter, or obscure this notice.  In the event you submit or
+provide any feedback, code, pull requests, or suggestions to New Relic you
+hereby grant New Relic a worldwide, non-exclusive, irrevocable, transferrable,
+fully paid-up license to use the code, algorithms, patents, and ideas therein in
+our products.
+
+All other use, reproduction, modification, distribution, or other exploitation
+of these files is strictly prohibited, except as may be set forth in a separate
+written license agreement between you and New Relic.  The terms of any such
+license agreement will control over this notice.  The license stated above will
+be automatically terminated and revoked if you exceed its scope or violate any
+of the terms of this notice.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of New Relic, except as required for reasonable
+and customary use in describing the origin of this file and reproducing the
+content of this notice.  You may not mark or brand this file with any trade
+name, trademarks, service marks, or product names other than the original brand
+(if any) provided by New Relic.
+
+Unless otherwise expressly agreed by New Relic in a separate written license
+agreement, these files are provided AS IS, WITHOUT WARRANTY OF ANY KIND,
+including without any implied warranties of MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE, TITLE, or NON-INFRINGEMENT.  As a condition to your use of
+these files, you are solely responsible for such use. New Relic will have no
+liability to you for direct, indirect, consequential, incidental, special, or
+punitive damages or for lost profits or data.
+
+```
+
+### coveralls
+
+This product includes source derived from [coveralls](https://github.com/nickmerwin/node-coveralls) ([v3.1.0](https://github.com/nickmerwin/node-coveralls/tree/v3.1.0)), distributed under the [BSD-2-Clause License](https://github.com/nickmerwin/node-coveralls/blob/v3.1.0/LICENSE):
+
+```
+Copyright (c) 2013, Coveralls, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of Coveralls, LLC.
+
+```
+
+### eslint
+
+This product includes source derived from [eslint](https://github.com/eslint/eslint) ([v5.16.0](https://github.com/eslint/eslint/tree/v5.16.0)), distributed under the [MIT License](https://github.com/eslint/eslint/blob/v5.16.0/LICENSE):
+
+```
+Copyright JS Foundation and other contributors, https://js.foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+```
+
+### koa-route
+
+This product includes source derived from [koa-route](https://github.com/koajs/route) ([v3.2.0](https://github.com/koajs/route/tree/3.2.0)), distributed under the [MIT License](https://github.com/koajs/route/blob/3.2.0/Readme.md):
+
+```
+MIT License Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
+
+### koa-router
+
+This product includes source derived from [koa-router](https://github.com/alexmingoia/koa-router) ([v7.4.0](https://github.com/alexmingoia/koa-router/tree/v7.4.0)), distributed under the [MIT License](https://github.com/alexmingoia/koa-router/blob/v7.4.0/LICENSE):
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2015 Alexander C. Mingoia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+```
+
+### koa
+
+This product includes source derived from [koa](https://github.com/koajs/koa) ([v2.7.0](https://github.com/koajs/koa/tree/2.7.0)), distributed under the [MIT License](https://github.com/koajs/koa/blob/2.7.0/LICENSE):
+
+```
+(The MIT License)
+
+Copyright (c) 2019 Koa contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+```
+
+### newrelic
+
+This product includes source derived from [newrelic](https://github.com/newrelic/node-newrelic) ([v6.11.0](https://github.com/newrelic/node-newrelic/tree/v6.11.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic/blob/v6.11.0/LICENSE):
+
+```
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+```
+
+### semver
+
+This product includes source derived from [semver](https://github.com/npm/node-semver) ([v5.7.1](https://github.com/npm/node-semver/tree/v5.7.1)), distributed under the [ISC License](https://github.com/npm/node-semver/blob/v5.7.1/LICENSE):
+
+```
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+```
+
+### tap
+
+This product includes source derived from [tap](https://github.com/tapjs/node-tap) ([v14.10.7](https://github.com/tapjs/node-tap/tree/v14.10.7)), distributed under the [ISC License](https://github.com/tapjs/node-tap/blob/v14.10.7/LICENSE):
+
+```
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+```
+

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "npm run unit && npm run versioned",
-    "unit": "tap tests/unit/**/*.tap.js",
+    "unit": "tap tests/unit/**/*.tap.js --no-coverage",
     "versioned": "versioned-tests --minor -i 2 'tests/versioned/*.tap.js'",
     "lint": "eslint *.js lib tests"
   },
@@ -21,14 +21,14 @@
   "devDependencies": {
     "@koa/router": "^8.0.0",
     "@newrelic/test-utilities": "^3.0.0",
-    "coveralls": "^3.0.0",
+    "coveralls": "^3.1.0",
     "eslint": "^5.8.0",
     "koa": "^2.6.1",
     "koa-route": "^3.2.0",
     "koa-router": "^7.4.0",
     "newrelic": "^5.13.0",
-    "semver": "^5.6.0",
-    "tap": "^14.7.1"
+    "semver": "^5.7.1",
+    "tap": "^14.10.7"
   },
   "dependencies": {
     "methods": "^1.1.2"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "koa": "^2.6.1",
     "koa-route": "^3.2.0",
     "koa-router": "^7.4.0",
-    "newrelic": "^5.13.0",
+    "newrelic": "^6.11.0",
     "semver": "^5.7.1",
     "tap": "^14.10.7"
   },
@@ -34,7 +34,7 @@
     "methods": "^1.1.2"
   },
   "peerDependencies": {
-    "newrelic": ">=5.13.0"
+    "newrelic": ">=6.11.0"
   },
   "repository": {
     "type": "git",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,0 +1,148 @@
+{
+  "lastUpdated": "Thu Jul 09 2020 14:58:40 GMT-0700 (Pacific Daylight Time)",
+  "projectName": "New Relic Koa Instrumentation",
+  "projectUrl": "https://github.com/newrelic/node-newrelic-koa",
+  "includeDev": true,
+  "dependencies": {
+    "methods@1.1.2": {
+      "name": "methods",
+      "version": "1.1.2",
+      "range": "^1.1.2",
+      "licenses": "MIT",
+      "repoUrl": "https://github.com/jshttp/methods",
+      "versionedRepoUrl": "https://github.com/jshttp/methods/tree/v1.1.2",
+      "licenseFile": "node_modules/methods/LICENSE",
+      "licenseUrl": "https://github.com/jshttp/methods/blob/v1.1.2/LICENSE",
+      "licenseTextSource": "file"
+    }
+  },
+  "devDependencies": {
+    "@koa/router@8.0.5": {
+      "name": "@koa/router",
+      "version": "8.0.5",
+      "range": "^8.0.0",
+      "licenses": "MIT",
+      "repoUrl": "https://github.com/koajs/koa-router",
+      "versionedRepoUrl": "https://github.com/koajs/koa-router/tree/v8.0.5",
+      "licenseFile": "node_modules/@koa/router/LICENSE",
+      "licenseUrl": "https://github.com/koajs/koa-router/blob/v8.0.5/LICENSE",
+      "licenseTextSource": "file",
+      "publisher": "Alex Mingoia",
+      "email": "talk@alexmingoia.com"
+    },
+    "@newrelic/test-utilities@3.0.0": {
+      "name": "@newrelic/test-utilities",
+      "version": "3.0.0",
+      "range": "^3.0.0",
+      "licenses": "proprietary",
+      "repoUrl": "https://github.com/newrelic/node-test-utilities",
+      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v3.0.0",
+      "licenseFile": "node_modules/@newrelic/test-utilities/README.md",
+      "licenseUrl": "https://github.com/newrelic/node-newrelic/blob/v6.10.0/LICENSE",
+      "licenseTextSource": "UNKNOWN",
+      "publisher": "New Relic Node.js agent team",
+      "email": "nodejs@newrelic.com",
+      "FOR_REVIEW": [
+        "Unable to determine source for license text."
+      ]
+    },
+    "coveralls@3.1.0": {
+      "name": "coveralls",
+      "version": "3.1.0",
+      "range": "^3.0.0",
+      "licenses": "BSD-2-Clause",
+      "repoUrl": "https://github.com/nickmerwin/node-coveralls",
+      "versionedRepoUrl": "https://github.com/nickmerwin/node-coveralls/tree/v3.1.0",
+      "licenseFile": "node_modules/tap/node_modules/coveralls/LICENSE",
+      "licenseUrl": "https://github.com/nickmerwin/node-coveralls/blob/v3.1.0/LICENSE",
+      "licenseTextSource": "file",
+      "publisher": "Gregg Caines"
+    },
+    "eslint@5.16.0": {
+      "name": "eslint",
+      "version": "5.16.0",
+      "range": "^5.8.0",
+      "licenses": "MIT",
+      "repoUrl": "https://github.com/eslint/eslint",
+      "versionedRepoUrl": "https://github.com/eslint/eslint/tree/v5.16.0",
+      "licenseFile": "node_modules/eslint/LICENSE",
+      "licenseUrl": "https://github.com/eslint/eslint/blob/v5.16.0/LICENSE",
+      "licenseTextSource": "file",
+      "publisher": "Nicholas C. Zakas",
+      "email": "nicholas+npm@nczconsulting.com"
+    },
+    "koa-route@3.2.0": {
+      "name": "koa-route",
+      "version": "3.2.0",
+      "range": "^3.2.0",
+      "licenses": "MIT",
+      "repoUrl": "https://github.com/koajs/route",
+      "versionedRepoUrl": "https://github.com/koajs/route/tree/3.2.0",
+      "licenseFile": "node_modules/koa-route/Readme.md",
+      "licenseUrl": "https://github.com/koajs/route/blob/3.2.0/Readme.md",
+      "licenseTextSource": "spdx"
+    },
+    "koa-router@7.4.0": {
+      "name": "koa-router",
+      "version": "7.4.0",
+      "range": "^7.4.0",
+      "licenses": "MIT",
+      "repoUrl": "https://github.com/alexmingoia/koa-router",
+      "versionedRepoUrl": "https://github.com/alexmingoia/koa-router/tree/v7.4.0",
+      "licenseFile": "node_modules/koa-router/LICENSE",
+      "licenseUrl": "https://github.com/alexmingoia/koa-router/blob/v7.4.0/LICENSE",
+      "licenseTextSource": "file",
+      "publisher": "Alex Mingoia",
+      "email": "talk@alexmingoia.com"
+    },
+    "koa@2.7.0": {
+      "name": "koa",
+      "version": "2.7.0",
+      "range": "^2.6.1",
+      "licenses": "MIT",
+      "repoUrl": "https://github.com/koajs/koa",
+      "versionedRepoUrl": "https://github.com/koajs/koa/tree/2.7.0",
+      "licenseFile": "node_modules/koa/LICENSE",
+      "licenseUrl": "https://github.com/koajs/koa/blob/2.7.0/LICENSE",
+      "licenseTextSource": "file"
+    },
+    "newrelic@6.11.0": {
+      "name": "newrelic",
+      "version": "6.11.0",
+      "range": "^6.11.0",
+      "licenses": "Apache-2.0",
+      "repoUrl": "https://github.com/newrelic/node-newrelic",
+      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic/tree/v6.11.0",
+      "licenseFile": "node_modules/newrelic/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-newrelic/blob/v6.11.0/LICENSE",
+      "licenseTextSource": "file",
+      "publisher": "New Relic Node.js agent team",
+      "email": "nodejs@newrelic.com"
+    },
+    "semver@5.7.1": {
+      "name": "semver",
+      "version": "5.7.1",
+      "range": "^5.6.0",
+      "licenses": "ISC",
+      "repoUrl": "https://github.com/npm/node-semver",
+      "versionedRepoUrl": "https://github.com/npm/node-semver/tree/v5.7.1",
+      "licenseFile": "node_modules/tap/node_modules/semver/LICENSE",
+      "licenseUrl": "https://github.com/npm/node-semver/blob/v5.7.1/LICENSE",
+      "licenseTextSource": "file"
+    },
+    "tap@14.10.7": {
+      "name": "tap",
+      "version": "14.10.7",
+      "range": "^14.10.7",
+      "licenses": "ISC",
+      "repoUrl": "https://github.com/tapjs/node-tap",
+      "versionedRepoUrl": "https://github.com/tapjs/node-tap/tree/v14.10.7",
+      "licenseFile": "node_modules/tap/LICENSE",
+      "licenseUrl": "https://github.com/tapjs/node-tap/blob/v14.10.7/LICENSE",
+      "licenseTextSource": "file",
+      "publisher": "Isaac Z. Schlueter",
+      "email": "i@izs.me",
+      "url": "http://blog.izs.me"
+    }
+  }
+}


### PR DESCRIPTION
## CHANGELOG

* Added third party notices file and metadata for dependencies.

* Bumped minimum versions of tap, coveralls and semver.

* Bumped minimum peer dependency (and dev dependency) of newrelic agent for license matching.

## INTERNAL LINKS

* Closes: https://github.com/newrelic/node-newrelic-koa/issues/37

## NOTES

**NOTE:** to have prod-level licensing alignment, bumped the minimum peer dep to agent ^v6.11.0. This results in a major version bump. Open to conversations there if we do not want to do this.