### PR TITLE
Bump @newrelic/test-utilities to v5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@koa/router": "^8.0.0",
-    "@newrelic/test-utilities": "^4.0.0",
+    "@newrelic/test-utilities": "^5.1.0",
     "eslint": "^5.8.0",
     "koa": "^2.6.1",
     "koa-route": "^3.2.0",


### PR DESCRIPTION
* Bumped `@newrelic/test-utilities` to ^5.1.0.
