### PR TITLE
Modifies koa test to remove context-less async hop.

### DIFF
--- a/tests/versioned/koa.tap.js
+++ b/tests/versioned/koa.tap.js
@@ -259,39 +259,37 @@ tap.test('Koa instrumentation', (t) => {
   })
 
   t.test('maintains transaction state between middleware', (t) => {
-    t.plan(5)
+    t.plan(7)
 
-    var tasks = []
-    var intervalId = setInterval(function () {
-      while (tasks.length) {
-        tasks.pop()()
-      }
-    }, 10)
+    let tx
 
-    t.tearDown(function () {
-      clearInterval(intervalId)
-    })
-    var tx
-
-    app.use(function one(ctx, next) {
+    app.use(async function one(ctx, next) {
       tx = helper.agent.getTransaction()
-      return new Promise(executor)
 
-      function executor(resolve) {
-        tasks.push(function () {
-          next().then(function () {
-            t.transaction(tx)
+      await next()
+
+      t.transaction(tx)
+    })
+
+    app.use(async function two(ctx, next) {
+      t.transaction(tx, 'two has transaction context')
+      await next()
+    })
+
+    app.use(function three(ctx, next) {
+      t.transaction(tx, 'three has transaction context')
+      return new Promise((resolve) => {
+        setImmediate(() => {
+          next().then(() => {
+            t.transaction(tx, 'still have context after in-context timer hop')
             resolve()
           })
         })
-      }
+      })
     })
-    app.use(function two(ctx, next) {
-      t.transaction(tx, 'two has transaction context')
-      return next()
-    })
-    app.use(function three(ctx) {
-      t.transaction(tx, 'three has transaction context')
+
+    app.use(function four(ctx) {
+      t.transaction(tx, 'four has transaction context')
       ctx.body = 'done'
     })
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Removed context-less timer hop from transaction state test.

  The context-less timer hope was not specific to koa execution. With the upcoming AsyncLocal implementation there are new limitations to boundaries we can track promises that cause this to fail. Given this setup is not specific to koa functionality, modifying to remove.

## Links

## Details
