### PR TITLE
update actions that are using deprecated node 12

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Troubleshooting
+    url:  https://github.com/newrelic/node-newrelic-koa/blob/main/README.md#support
+    about: Check out the README for troubleshooting directions
+

--- a/.github/ISSUE_TEMPLATE/troubleshooting.md
+++ b/.github/ISSUE_TEMPLATE/troubleshooting.md
@@ -1,5 +1,0 @@
-<!-- ⚠️⚠️STOP⚠️⚠️ -- PLEASE READ! -->
-
-We use GitHub to track feature requests and bug reports. Please **do not** submit issues for questions about how to configure, use features, troubleshoot, or best practices for using New Relic software.
-
-See the README.md support section in this repository for more details on self-service troubleshooting tooling, links to our comprehensive documentation, and how to get further support.

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -11,9 +11,9 @@ jobs:
         node-version: [lts/*]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
@@ -29,9 +29,9 @@ jobs:
         node-version: [14.x, 16.x, 18.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
@@ -47,9 +47,9 @@ jobs:
         node-version: [14.x, 16.x, 18.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -22,7 +22,7 @@ jobs:
             return data.data && data.data.default_branch === context.ref.split('/').slice(-1)[0]
       - name: Checkout Self
         if: ${{ steps.default-branch.outputs.result == 'true' }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run Repolinter
         if: ${{ steps.default-branch.outputs.result == 'true' }}
         uses: newrelic/repolinter-action@v1

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Test Default Branch
         id: default-branch
-        uses: actions/github-script@v2
+        uses: actions/github-script@v6
         with:
           script: |
             const data = await github.repos.get(context.repo)

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const data = await github.repos.get(context.repo)
+            const data = await github.rest.repos.get(context.repo)
             return data.data && data.data.default_branch === context.ref.split('/').slice(-1)[0]
       - name: Checkout Self
         if: ${{ steps.default-branch.outputs.result == 'true' }}


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
I just happen to notice this while waiting for the [agent to be released](https://github.com/newrelic/node-newrelic/actions/runs/3315379709).

Github actions removed [Node 12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) as a runner.  This PR fixes all instances that rely on Node.js 12.


