### PR TITLE
chore: removed newrelic as peer dep as standalone is no longer supported

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,9 +33,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "newrelic": ">=6.11.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -50,9 +50,6 @@
     "sinon": "^15.0.1",
     "tap": "^16.0.1"
   },
-  "peerDependencies": {
-    "newrelic": ">=6.11.0"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/newrelic/node-newrelic-koa.git"

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Wed Aug 30 2023 11:31:47 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Tue Oct 24 2023 17:02:13 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Koa Instrumentation",
   "projectUrl": "https://github.com/newrelic/node-newrelic-koa",
   "includeOptDeps": false,


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Removed `newrelic` as peer dependency since this package only gets bundled with agent.

## Links

## Details
